### PR TITLE
Fix path for loading plugin to work with kit-server

### DIFF
--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -94,7 +94,7 @@ class Deploymentizer {
 			this.paths.images = resolve(this.options.workdir, conf.images.path);
 			if (conf.plugin) {
 				this.options.configPlugin = conf.plugin;
-				this.options.configPlugin.path = resolve(this.options.workdir, conf.plugin.path);
+				this.options.configPlugin.path = conf.plugin.path;
 			}
 			Object.keys(this.paths).forEach( (key) => {
 				if (!this.paths[key]) {

--- a/src/util/plugin-handler.js
+++ b/src/util/plugin-handler.js
@@ -14,6 +14,7 @@ class PluginHandler {
 	 * @return {[type]}            [description]
 	 */
 	constructor(pluginPath, options) {
+		eventHandler.emitInfo(`Plugin path used: ${pluginPath}`);
 		const plugin = require(pluginPath)
 		this.configService = new plugin(options);
 	}

--- a/test/fixture/kit.yaml
+++ b/test/fixture/kit.yaml
@@ -13,7 +13,7 @@ resources:
 output:
   path: /generated
 plugin:
-  path: /src/plugin/file-config
+  path: "../plugin/file-config"
   options:
     configPath: "/test/fixture/config"
 


### PR DESCRIPTION
kit-server sets the workdir to the kubernetes-coreos dir, so this should not be used for looking up a plugin. The plugin should be relative to code requiring it for portability