### PR TITLE
Fails if call to plugin fails and you can specify single service generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ plugin:
 
 ##### base-cluster.yaml
 
-Defines the over all list of resources. These are included by default in all local cluster configuration unless explicitly disabled.
+Defines the over all list of resources. 
+These are included by default in all local cluster configuration unless explicitly disabled.
 
 
 ```
@@ -216,7 +217,10 @@ You can override individual resource values here, including which branch a resou
 The name of the external ENV must match the defined name in the `resource.[RESOURCE-NAME].env.name` definition.
 
 ##### Disable a Service
-In order to disable a service for a specific cluster, add the `resources.[RESOURCE-NAME].disable: true`. This will keep the `deploymentizer` from generating a deployment/service file for that specific resource.
+By default any resource defined in a cluster is considered enabled. You can explicitly change this by setting the value `disable: true`.  
+For example, in order to disable a service for a specific cluster, add the `resources.[RESOURCE-NAME].disable: true`. This will keep the `deploymentizer` from generating a deployment/service file for that specific resource. 
+If managing lots of clusters, it can be helpful to define your resource in the base cluster file, but configure it as `disable: true` initially. Then only enable it for clusters your want that service deployed on. 
+The other option is to configure it in the base cluster as `disable: false` and enabled it specifically for each cluster.
 
 ##### Adding a Service
 You can add a service just for the cluster by defining the values here. This would allow you to test a service only on a specific cluster before rolling it out to all clusters. The required fields would be:
@@ -371,7 +375,7 @@ plugin:
     configPath: "/test/fixture/config"
 ```
 
-Calling this with any invalid values (ie wrong service, cluster) should return a error.  This will be logged and skipped - not halt processing.
+Calling this with any invalid values (ie wrong service, cluster) should return a error and will stop processing.
 
 This will be required at system startup and executed _asynchronously_ for every Resource listed in the cluster definition.
 
@@ -431,6 +435,7 @@ The following environment variables are used by this service.
 | `CLEAN` | Set if the output directory should be deleted and re-created before generating manifest files | yes | `false` |
 | `SAVE` | Sets if the generated manifest files are saved to the output diretory or not | yes | `true` |
 | `CONF` | Sets the path the config file to load | yes | `/manifests/kit.yaml` |
+| `RESOURCE` | Defines specific resource to generate. If not set, generates all resources. | no | `` |
 
 ## Contributing
 

--- a/src/deploymentizer
+++ b/src/deploymentizer
@@ -57,6 +57,7 @@ program
 	.option("-w, --workdir <string>", "Sets the working directory for reading paths defined in the conf file. Allows absolute paths in conf also.", process.env.WORKDIR)
 	.option("-k, --conf <string>", "Sets the configure file to load at start up - Required.", process.env.CONF)
 	.option("-d, --debug <boolean>", "Sets debug flag", parseBoolean, parseBoolean(process.env.DEBUG))
+	.option("-r, --resource <string>", "Sets the resource to generate", process.env.RESOURCE)
 	.parse(process.argv)
 ;
 
@@ -81,7 +82,8 @@ loadConf(program.conf).then( (conf) => {
 		clean: program.clean,
 		save: program.save,
 		workdir: program.workdir,
-		conf: conf
+		conf: conf,
+		resource: program.resource
 	});
 	// Run the deploymentizer
 	return deploymentizer.process()
@@ -89,7 +91,7 @@ loadConf(program.conf).then( (conf) => {
 			exit(0);
 		})
 		.catch(function(err) {
-			logger.fatal(err);
+			logger.fatal(err.message || err);
 			throw new Error(err);
 		})
 		.done();

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -38,6 +38,7 @@ class Deploymentizer {
 				workdir: (args.workdir || ""),
 				configPlugin: undefined,
 				conf: undefined,
+				resource: (args.resource || undefined)
 			}
 		this.options.conf = this.parseConf(args.conf);
 		this.events = eventHandler;
@@ -134,7 +135,8 @@ class Deploymentizer {
 																			this.paths.resources,
 																			this.paths.output,
 																			this.options.save,
-																			configPlugin);
+																			configPlugin,
+																			this.options.resource);
 			return generator.process();
 		});
 	}

--- a/src/plugin/env-api-client.js
+++ b/src/plugin/env-api-client.js
@@ -73,7 +73,7 @@ class EnvApiClient {
 				qs: query,
 				headers: { 'X-Auth-Token': this.apiToken },
 				json: true,
-				timeout: 3000
+				timeout: 10000
 			};
 			let config = yield rp(options);
 

--- a/src/util/plugin-handler.js
+++ b/src/util/plugin-handler.js
@@ -39,8 +39,8 @@ class PluginHandler {
 		return Promise.resolve(
 				this.configService.fetch( service, cluster )
 			).catch( (err) => {
-				eventHandler.emitWarn(`Configuration could not be loaded for ${service.name} for cluster ${cluster}`);
-				return {};
+				eventHandler.emitFatal(`Configuration could not be loaded for ${service.name} for cluster ${cluster} stopping processing.`);
+				throw err;
 			});
 	}
 }

--- a/test/fixture/clusters/other-cluster/cluster.yaml
+++ b/test/fixture/clusters/other-cluster/cluster.yaml
@@ -18,7 +18,7 @@ resources:
           - name: test
             value: testvalue
   activity:
-    disable: true
+    disable: false
 
   envsecret:
     disable: true

--- a/test/fixture/config/activity/other-test-fixture-env.json
+++ b/test/fixture/config/activity/other-test-fixture-env.json
@@ -1,0 +1,11 @@
+{
+  "env": [
+    { "name": "ENV_ONE", "value": "value one"},
+    { "name": "ENV_TWO", "value": "value two"},
+    { "name": "ENV_THREE", "value": "value three"}
+  ],
+  "branch": "master",
+  "deployment": {
+    "replicaCount": 2
+  }
+}

--- a/test/fixture/config/activity/test-fixture-env.json
+++ b/test/fixture/config/activity/test-fixture-env.json
@@ -1,0 +1,11 @@
+{
+  "env": [
+    { "name": "ENV_ONE", "value": "value one"},
+    { "name": "ENV_TWO", "value": "value two"},
+    { "name": "ENV_THREE", "value": "value three"}
+  ],
+  "branch": "master",
+  "deployment": {
+    "replicaCount": 10
+  }
+}

--- a/test/fixture/config/auth/other-test-fixture-env.json
+++ b/test/fixture/config/auth/other-test-fixture-env.json
@@ -1,0 +1,11 @@
+{
+  "env": [
+    { "name": "ENV_ONE", "value": "value one"},
+    { "name": "ENV_TWO", "value": "value two"},
+    { "name": "ENV_THREE", "value": "value three"}
+  ],
+  "branch": "master",
+  "deployment": {
+    "replicaCount": 10
+  }
+}

--- a/test/fixture/config/envsecret/test-fixture-env.json
+++ b/test/fixture/config/envsecret/test-fixture-env.json
@@ -1,0 +1,7 @@
+{
+  "env": [
+    { "name": "ENV_ONE", "value": "value one"},
+    { "name": "ENV_TWO", "value": "value two"},
+    { "name": "ENV_THREE", "value": "value three"}
+  ]
+}

--- a/test/fixture/images/invision/node-activity/test.yaml
+++ b/test/fixture/images/invision/node-activity/test.yaml
@@ -1,0 +1,1 @@
+image: 'quay.io/invision/node-activity:test-73e5e12e3bbed6c5935541ebf7b17e997ebd1bc7'

--- a/test/unit/util/plugin-handler.spec.js
+++ b/test/unit/util/plugin-handler.spec.js
@@ -34,15 +34,15 @@ describe("PluginHandler", () =>  {
 			});
 		});
 
-		it("should not fail even with file not found", (done) => {
+		it("should fail with file not found", (done) => {
 			Promise.coroutine(function* () {
         const options = { configPath: "./test/fixture/config" }
   			const handler = new PluginHandler("../../../src/plugin/file-config", options);
 				expect(handler).to.exist;
 				const config = yield handler.fetch( { name: "service" }, "not-here" )
-				done();
-			})().catch( (err) => {
 				done(err);
+			})().catch( (err) => {
+				done();
 			});
 		});
 


### PR DESCRIPTION
# What

PR contains two changes:

1. Fails if plugin returns error. This behavior is different from previous, before it would just log the error and continue.
1. Excepts a resource name and if supplied will only generate manifests for that resource. This will include the service file if specified.

Added tests to validate both scenarios.