### PR TITLE
added the ability to disable entire clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ metadata:
   name: [Name of Cluster - required]
   branch: [Branch used for deployment of cluster, can be overridden at the resource level]
   type: [ type of cluster, used to import type specific deployment information, can be overridden at the resource level]
+  disable: [ set to true to have deploymentizer skip processing of this cluster ]
 ```
 An example file would look like:
 

--- a/src/lib/cluster-definition.js
+++ b/src/lib/cluster-definition.js
@@ -48,6 +48,15 @@ class ClusterDefinition {
 	}
 
 	/**
+	 * Clusters can be disabled by adding a metadata.disable == true
+	 * This will keep the cluster from being generated.
+	 * @return {boolean} if a cluster has been marked disable === true
+	 */
+	disabled() {
+		return (this.cluster.metadata.disable && this.cluster.metadata.disable === true);
+	}
+
+	/**
 	 * Resources for this cluster
 	 * @return { "resource-name": data, ...} resource map by name
 	 */

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -128,16 +128,21 @@ class Deploymentizer {
 			// Merge with the Base Definitions.
 			def.apply(baseClusterDef);
 			this.events.emitInfo("Done Merging Cluster Definitions");
-			// apply the correct image tag based on cluster type or resource type
-			// generating the templates for each resource (if not disabled), using custom ENVs and envs from resource tags.
-			// Save files out
-			const generator = new Generator(def, imageResources,
-																			this.paths.resources,
-																			this.paths.output,
-																			this.options.save,
-																			configPlugin,
-																			this.options.resource);
-			return generator.process();
+			if (def.disabled()) {
+				this.events.emitInfo(`Cluster ${def.name()} is disabled, skipping`);
+				return;
+			} else {
+				// apply the correct image tag based on cluster type or resource type
+				// generating the templates for each resource (if not disabled), using custom ENVs and envs from resource tags.
+				// Save files out
+				const generator = new Generator(def, imageResources,
+																				this.paths.resources,
+																				this.paths.output,
+																				this.options.save,
+																				configPlugin,
+																				this.options.resource);
+				return generator.process();
+			}
 		});
 	}
 }

--- a/test/fixture/clusters/disabled-cluster/cluster.yaml
+++ b/test/fixture/clusters/disabled-cluster/cluster.yaml
@@ -1,0 +1,26 @@
+kind: ClusterNamespace
+metadata:
+  name: disabled-test-fixture
+  branch: testing
+  type: test
+  disable: true
+resources:
+  auth:
+    disable: false
+    svc:
+      name: auth-svc
+      labels:
+        - name: "app"
+          value: "invisionapp"
+    containers:
+      auth-con:
+        name: auth
+        env:
+          - name: test
+            value: testvalue
+  activity:
+    disable: false
+
+  envsecret:
+    disable: true
+

--- a/test/fixture/clusters/disabled-cluster/configuration-var.yaml
+++ b/test/fixture/clusters/disabled-cluster/configuration-var.yaml
@@ -1,0 +1,3 @@
+kind: ResourceConfig
+deployment:
+  replicaCount: 0

--- a/test/functional/lib/deploymentizer.spec.js
+++ b/test/functional/lib/deploymentizer.spec.js
@@ -152,5 +152,30 @@ describe("Deploymentizer", () => {
 				done(err);
 			});
 		});
+
+		it("should not generate disabled cluster", (done) => {
+
+			Promise.coroutine(function* () {
+				fse.mkdirsSync(path.join(os.tmpdir(), "generated"));
+				let conf = yield yamlHandler.loadFile("/test/fixture/kit.yaml");
+
+				const deployer = new Deploymentizer ({
+						clean: true,
+						save: true,
+						conf: conf
+					});
+				expect(deployer).to.exist;
+				// generate the files from our test fixtures
+				yield deployer.process();
+				// disabled this cluster
+				const clusterDir = fse.existsSync(path.join(os.tmpdir(), "generated", "disabled-test-fixture"));
+				expect(clusterDir).to.be.false;
+
+				done();
+			})().catch( (err) => {
+				done(err);
+			});
+		});
+
 	});
 });

--- a/test/unit/lib/cluster-definition.spec.js
+++ b/test/unit/lib/cluster-definition.spec.js
@@ -82,8 +82,8 @@ describe("Cluster Definitions", () =>  {
 			return Promise.coroutine(function* () {
 				const clusterDefs = yield yamlHandler.loadClusterDefinitions("./test/fixture/clusters");
 				expect(clusterDefs).to.exist;
-				expect(clusterDefs.length).to.equal(2);
-				const clusterDef = clusterDefs[1];
+				expect(clusterDefs.length).to.equal(3);
+				const clusterDef = clusterDefs[2];
 				expect(clusterDef).to.exist;
 				expect(clusterDef.name()).to.equal("test-fixture");
 				expect(clusterDef.type()).to.equal("test");
@@ -100,10 +100,10 @@ describe("Cluster Definitions", () =>  {
 			return Promise.coroutine(function* () {
 				const clusterDefs = yield yamlHandler.loadClusterDefinitions("./test/fixture/clusters");
 				expect(clusterDefs).to.exist;
-				expect(clusterDefs.length).to.equal(2);
+				expect(clusterDefs.length).to.equal(3);
 
 				// Load Cluster Def
-				const clusterDef = clusterDefs[1];
+				const clusterDef = clusterDefs[2];
 				expect(clusterDef).to.exist;
 				expect(clusterDef.name()).to.equal("test-fixture");
 				expect(clusterDef.rsConfig.deployment).to.exist;

--- a/test/unit/lib/generator.spec.js
+++ b/test/unit/lib/generator.spec.js
@@ -25,7 +25,7 @@ describe("Generator", () => {
 		it("should create valid service file", (done) => {
 			return Promise.coroutine(function* () {
 				const clusterDefs = yield yamlHandler.loadClusterDefinitions("./test/fixture/clusters");
-				const clusterDef = clusterDefs[0];
+				const clusterDef = clusterDefs[1];
 				const generator = new Generator(clusterDef, {}, "./test/fixture/resources", os.tmpdir(), true, configStub);
 				expect(clusterDef).to.exist;
 				if (!fse.existsSync( path.join(os.tmpdir(), clusterDef.name())) ) {
@@ -50,7 +50,7 @@ describe("Generator", () => {
 
 			return Promise.coroutine(function* () {
 				const clusterDefs = yield yamlHandler.loadClusterDefinitions("./test/fixture/clusters");
-				const clusterDef = clusterDefs[1];
+				const clusterDef = clusterDefs[2];
 				const generator = new Generator(clusterDef, imageResources, "./test/fixture/resources", os.tmpdir(), true, configStub);
 				expect(clusterDef).to.exist;
 				if (!fse.existsSync( path.join(os.tmpdir(), clusterDef.name())) ) {
@@ -79,7 +79,7 @@ describe("Generator", () => {
 
 			return Promise.coroutine(function* () {
 				const clusterDefs = yield yamlHandler.loadClusterDefinitions("./test/fixture/clusters");
-				const clusterDef = clusterDefs[1];
+				const clusterDef = clusterDefs[2];
 				const generator = new Generator(clusterDef, imageResources, "./test/fixture/resources", os.tmpdir(), true, undefined);
 				expect(clusterDef).to.exist;
 				if (!fse.existsSync( path.join(os.tmpdir(), clusterDef.name())) ) {


### PR DESCRIPTION
# What

Add the ability to disable entire clusters. This will allow work on a cluster to be defined without stopping deployments, if all of the clusters services are not configured yet.