### PR TITLE
Env api timeout option

### DIFF
--- a/src/plugin/env-api-client.js
+++ b/src/plugin/env-api-client.js
@@ -19,6 +19,7 @@ class EnvApiClient {
 		}
 		this.apiUrl = options.apiUrl;
 		this.apiToken = options.apiToken;
+		this.timeout = (options.timeout || 15000);
 	}
 
 	/**
@@ -73,7 +74,7 @@ class EnvApiClient {
 				qs: query,
 				headers: { 'X-Auth-Token': this.apiToken },
 				json: true,
-				timeout: 10000
+				timeout: this.timeout
 			};
 			let config = yield rp(options);
 

--- a/test/fixture/kit.yaml
+++ b/test/fixture/kit.yaml
@@ -22,3 +22,4 @@ plugin:
 #  options:
 #    apiUrl: "http://somehost/v1/api"
 #    apiToken: "s0me-t0ken-g0es-here"
+#    timeout: 30000

--- a/test/unit/plugin/env-api-client.spec.js
+++ b/test/unit/plugin/env-api-client.spec.js
@@ -37,6 +37,14 @@ describe("ENV API Client Configuration plugin", () =>  {
       expect(apiConfig.timeout).to.equal(20000);
 			done();
 		});
+		it("should load plugin successfully and default timeout", (done) => {
+      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN"}
+			const ApiConfig = require("../../../src/plugin/env-api-client");
+      const apiConfig = new ApiConfig(options);
+      expect(apiConfig).to.exist;
+      expect(apiConfig.timeout).to.equal(15000);
+			done();
+		});
 	});
 
 });

--- a/test/unit/plugin/env-api-client.spec.js
+++ b/test/unit/plugin/env-api-client.spec.js
@@ -28,12 +28,13 @@ describe("ENV API Client Configuration plugin", () =>  {
 		});
 
 		it("should load plugin successfully", (done) => {
-      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN"}
+      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", timeout: 20000}
 			const ApiConfig = require("../../../src/plugin/env-api-client");
       const apiConfig = new ApiConfig(options);
       expect(apiConfig).to.exist;
       expect(apiConfig.apiToken).to.equal("SOME-TOKEN");
       expect(apiConfig.apiUrl).to.equal("http://somehost/v1");
+      expect(apiConfig.timeout).to.equal(20000);
 			done();
 		});
 	});


### PR DESCRIPTION
# What

Allow the env-api call's timeout value to be configured from kit.yaml. This should have been done in the first place.