### PR TITLE
allow the k8s branch to set the branch to get env.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "mocha": "2.4.5"
+    "mocha": "2.4.5",
+    "sinon": "1.17.6"
   },
   "files": [
     "LICENSE",

--- a/src/plugin/env-api-client.js
+++ b/src/plugin/env-api-client.js
@@ -20,7 +20,7 @@ class EnvApiClient {
 		this.apiUrl = options.apiUrl;
 		this.apiToken = options.apiToken;
 		this.timeout = (options.timeout || 15000);
-		this.altBranch = ( (options.altBranch === true) || false);
+		this.k8sBranch = ( (options.k8sBranch === true) || false);
 		this.request = rp;
 	}
 
@@ -35,7 +35,7 @@ class EnvApiClient {
 		return "kit-deploymentizer/env-api-branch";
 	}
 	/**
-	 * The provided service resource needs to contain a annotation specifiying the service name
+	 * The provided service resource needs to contain an annotation specifiying the service name
 	 * to use when invoking the env-api service. If this annotation is not present the request
 	 * is skipped. The annotation is `kit-deploymentizer/env-api-service: [GIT-HUB-PROJECT-NAME]`
 	 *
@@ -81,7 +81,7 @@ class EnvApiClient {
 			let config = yield this.request(options);
 			let result = {};
 			result = this.convertK8sResult(config, result);
-			if (this.altBranch && result.branch && result.branch !== query.branch) {
+			if (this.k8sBranch && result.branch && result.branch !== query.branch) {
 				eventHandler.emitInfo(`Pulling envs from ${result.branch} branch`);
 				options.qs.branch = result.branch;
 				config = yield this.request(options);
@@ -96,7 +96,7 @@ class EnvApiClient {
 	}
 
 	/**
-   * Converts the returned results from the env-api service into the expected format.
+	 * Converts the returned results from the env-api service into the expected format.
 	 */
 	convertK8sResult(config, result) {
 		// move the k8s values to the base object
@@ -110,7 +110,7 @@ class EnvApiClient {
 	}
 
 	/**
-   * Converts the returned results from the env-api service into the expected format.
+	 * Converts the returned results from the env-api service into the expected format.
 	 */
 	convertEnvResult(config, result) {
 		// convert env section to correct format

--- a/src/plugin/env-api-client.js
+++ b/src/plugin/env-api-client.js
@@ -8,7 +8,7 @@ const eventHandler = require("../util/event-handler");
  * Class for accessing the EnvApi Service.
  */
 class EnvApiClient {
-	
+
 	/**
 	 * Requires the apiUrl and apiToken to be set included as parameters.
 	 * @param  {[type]} options
@@ -20,6 +20,8 @@ class EnvApiClient {
 		this.apiUrl = options.apiUrl;
 		this.apiToken = options.apiToken;
 		this.timeout = (options.timeout || 15000);
+		this.altBranch = ( (options.altBranch === true) || false);
+		this.request = rp;
 	}
 
 	/**
@@ -33,13 +35,13 @@ class EnvApiClient {
 		return "kit-deploymentizer/env-api-branch";
 	}
 	/**
-	 * The provided service resource needs to contain a annotation specifiying the service name 
-	 * to use when invoking the env-api service. If this annotation is not present the request 
+	 * The provided service resource needs to contain a annotation specifiying the service name
+	 * to use when invoking the env-api service. If this annotation is not present the request
 	 * is skipped. The annotation is `kit-deploymentizer/env-api-service: [GIT-HUB-PROJECT-NAME]`
-	 * 
-	 * Another, optional, annotation sets the branch to use by the env-api service. This annotation 
-	 * is `kit-deploymentizer/env-api-branch: [GIT-HUB-BRANCH-NAME]` 
-	 * 
+	 *
+	 * Another, optional, annotation sets the branch to use by the env-api service. This annotation
+	 * is `kit-deploymentizer/env-api-branch: [GIT-HUB-BRANCH-NAME]`
+	 *
 	 * Expects JSON results in the format of:
 	 * {
 	 *   env: {
@@ -69,43 +71,59 @@ class EnvApiClient {
 			if (service.annotations || service.annotations[EnvApiClient.annotationBranchName]) {
 				query.branch = service.annotations[EnvApiClient.annotationBranchName]
 			}
-			const options = {
+			let options = {
 				uri: uri,
 				qs: query,
 				headers: { 'X-Auth-Token': this.apiToken },
 				json: true,
 				timeout: this.timeout
 			};
-			let config = yield rp(options);
-
-			// convert env section to correct format
+			let config = yield this.request(options);
 			let result = {};
-			result.env = []
-			if ( config.env ) {
-				Object.keys(config.env).forEach( (key) => {
-					result.env.push({
-						name: key,
-						value: config.env[key]
-					});
-				});
+			result = this.convertK8sResult(config, result);
+			if (this.altBranch && result.branch && result.branch !== query.branch) {
+				eventHandler.emitInfo(`Pulling envs from ${result.branch} branch`);
+				options.qs.branch = result.branch;
+				config = yield this.request(options);
 			}
-			// move the k8s values to the base object
-			if (config.k8s && typeof config.k8s === 'object') {
-				let props = config.k8s;
-				// if we get back a cluster level object, just parse that - otherwise use default
-				if (config.k8s[cluster]) {
-					props = config.k8s[cluster]
-				} 
-				Object.keys(props).forEach( (key) => {
-					result[key] = props[key];
-				});
-			}
+			result = this.convertEnvResult(config, result);
 			return result;
 		}).bind(this)().catch(function (err) {
 			// API call failed...
 			eventHandler.emitFatal(`Unable to fetch or convert ENV Config ${JSON.stringify(err)}`);
 			throw err;
 		});
+	}
+
+	/**
+   * Converts the returned results from the env-api service into the expected format.
+	 */
+	convertK8sResult(config, result) {
+		// move the k8s values to the base object
+		if (config.k8s && typeof config.k8s === 'object') {
+			let props = config.k8s;
+			Object.keys(props).forEach( (key) => {
+				result[key] = props[key];
+			});
+		}
+		return result;
+	}
+
+	/**
+   * Converts the returned results from the env-api service into the expected format.
+	 */
+	convertEnvResult(config, result) {
+		// convert env section to correct format
+		result.env = []
+		if ( config.env ) {
+			Object.keys(config.env).forEach( (key) => {
+				result.env.push({
+					name: key,
+					value: config.env[key]
+				});
+			});
+		}
+		return result;
 	}
 
 }

--- a/test/functional/helper.js
+++ b/test/functional/helper.js
@@ -7,16 +7,16 @@ var eventHandler = require("../../src/util/event-handler");
  */
 before( () => {
 
-  // Enable logging of all events from the deploymentizer
-  eventHandler.on(eventHandler.INFO, function(message) {
-  	logger.info(message);
-  });
-  eventHandler.on(eventHandler.WARN, function(message) {
-  	logger.warn(message);
-  });
-  eventHandler.on(eventHandler.FATAL, function(message) {
-  	logger.fatal(message);
-  });
+	// Enable logging of all events from the deploymentizer
+	eventHandler.on(eventHandler.INFO, function(message) {
+		logger.info(message);
+	});
+	eventHandler.on(eventHandler.WARN, function(message) {
+		logger.warn(message);
+	});
+	eventHandler.on(eventHandler.FATAL, function(message) {
+		logger.fatal(message);
+	});
 	eventHandler.on(eventHandler.DEBUG, function(message) {
 		logger.debug(message);
 	});

--- a/test/unit/plugin/env-api-client.spec.js
+++ b/test/unit/plugin/env-api-client.spec.js
@@ -2,6 +2,7 @@
 
 var expect = require("chai").expect;
 const Promise = require("bluebird");
+const sinon = require("sinon");
 
 describe("ENV API Client Configuration plugin", () =>  {
 
@@ -45,6 +46,174 @@ describe("ENV API Client Configuration plugin", () =>  {
       expect(apiConfig.timeout).to.equal(15000);
 			done();
 		});
+	});
+
+	describe("Client calls", () =>  {
+
+		it("should only call request to env-api once, and convert values", (done) => {
+			Promise.coroutine(function* () {
+				const responseOne = new Promise( (resolve, reject) => {
+					resolve(
+					{
+					  "env": {
+					    "GET_HOSTS_FROM": "dns",
+					    "MAX_RETRIES": "0",
+					    "MEMBER_HOSTS": "mongoreplica-01-svc:27017,mongoreplica-02-svc:27017,mongoreplica-03-svc:27017",
+					    "REPLICA_SET_NAME": "rs0",
+					    "WAIT_TIME": "60000"
+					  },
+					  "k8s": {
+					    "branch": "develop"
+					  }
+					});
+				});
+				var rp = sinon.stub();
+				rp.onFirstCall().returns(responseOne);
+					// .onSecondCall().returns(2);
+	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", altBranch: true };
+				const ApiConfig = require("../../../src/plugin/env-api-client");
+	      const apiConfig = new ApiConfig(options);
+				apiConfig.request = rp;
+
+				const service = {
+					name: "mongo-init",
+					annotations: {
+						"kit-deploymentizer/env-api-service": "mongo-init",
+						"kit-deploymentizer/env-api-branch": "develop"
+					}
+				}
+				const envs = yield apiConfig.fetch(service, "example-cluster");
+				console.log("Resolved ENVS: %j", envs);
+				expect(rp.callCount).to.equal(1);
+				let calledWith = rp.getCall(0);
+				// assert that the second call was to testing branch
+				expect(calledWith.args[0].qs.branch).to.equal("develop");
+				expect(calledWith.args[0].qs.env).to.equal("example-cluster");
+				expect(envs.branch).to.equal("develop");
+				expect(envs.env.length).to.equal(5);
+				expect(envs.env[0].name).to.equal("GET_HOSTS_FROM");
+				expect(envs.env[0].value).to.equal("dns");
+				expect(envs.env[1].name).to.equal("MAX_RETRIES");
+				expect(envs.env[1].value).to.equal("0");
+				done();
+			})().catch( (err) => {
+				done(err);
+			});
+		});
+
+		it("should call request to env-api twice, and get correct values", (done) => {
+			Promise.coroutine(function* () {
+				// ResponseOne is returned that says use testing branch,
+				// Request is invoked again passing in branch testing
+				// those values are used, but initial requests branch is kept.
+				const responseOne = new Promise( (resolve, reject) => {
+					resolve(
+					{
+					  "env": {
+					    "GET_HOSTS_FROM": "dns",
+					    "MAX_RETRIES": "0",
+					    "WAIT_TIME": "60000"
+					  },
+					  "k8s": {
+					    "branch": "testing"
+					  }
+					});
+				});
+				const responseTwo = new Promise( (resolve, reject) => {
+					resolve(
+					{
+					  "env": {
+					    "GET_HOSTS_FROM": "dns",
+					    "MAX_RETRIES": "5",
+					    "WAIT_TIME": "10000"
+					  },
+					  "k8s": {
+					    "branch": "develop"
+					  }
+					});
+				});
+				var rp = sinon.stub();
+				rp.onFirstCall().returns(responseOne)
+					.onSecondCall().returns(responseTwo);
+	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", altBranch: true };
+				const ApiConfig = require("../../../src/plugin/env-api-client");
+	      const apiConfig = new ApiConfig(options);
+				apiConfig.request = rp;
+
+				const service = {
+					name: "mongo-init",
+					annotations: {
+						"kit-deploymentizer/env-api-service": "mongo-init",
+						"kit-deploymentizer/env-api-branch": "develop"
+					}
+				}
+				const envs = yield apiConfig.fetch(service, "example-cluster");
+				console.log("Resolved ENVS: %j", envs);
+				expect(rp.callCount).to.equal(2);
+				let calledWith = rp.getCall(1);
+				// assert that the second call was to testing branch
+				expect(calledWith.args[0].qs.branch).to.equal("testing");
+				expect(envs.branch).to.equal("testing");
+				expect(envs.env.length).to.equal(3);
+				expect(envs.env[1].name).to.equal("MAX_RETRIES");
+				expect(envs.env[1].value).to.equal("5");
+				expect(envs.env[2].name).to.equal("WAIT_TIME");
+				expect(envs.env[2].value).to.equal("10000");
+				done();
+			})().catch( (err) => {
+				done(err);
+			});
+		});
+
+		it("should call request to env-api once, altbranch disabled", (done) => {
+			Promise.coroutine(function* () {
+				// ResponseOne is returned that says use testing branch,
+				// Request is invoked again passing in branch testing
+				// those values are used, but initial requests branch is kept.
+				const responseOne = new Promise( (resolve, reject) => {
+					resolve(
+					{
+					  "env": {
+					    "GET_HOSTS_FROM": "dns",
+					    "MAX_RETRIES": "0",
+					    "WAIT_TIME": "60000"
+					  },
+					  "k8s": {
+					    "branch": "testing"
+					  }
+					});
+				});
+				var rp = sinon.stub();
+				rp.onFirstCall().returns(responseOne)
+					.onSecondCall().returns({});
+	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN" };
+				const ApiConfig = require("../../../src/plugin/env-api-client");
+	      const apiConfig = new ApiConfig(options);
+				apiConfig.request = rp;
+
+				const service = {
+					name: "mongo-init",
+					annotations: {
+						"kit-deploymentizer/env-api-service": "mongo-init",
+						"kit-deploymentizer/env-api-branch": "develop"
+					}
+				}
+				const envs = yield apiConfig.fetch(service, "example-cluster");
+				console.log("Resolved ENVS: %j", envs);
+				expect(rp.callCount).to.equal(1);
+				expect(envs.branch).to.equal("testing");
+				expect(envs.env.length).to.equal(3);
+				expect(envs.env[1].name).to.equal("MAX_RETRIES");
+				expect(envs.env[1].value).to.equal("0");
+				expect(envs.env[2].name).to.equal("WAIT_TIME");
+				expect(envs.env[2].value).to.equal("60000");
+				done();
+			})().catch( (err) => {
+				done(err);
+			});
+
+		});
+
 	});
 
 });

--- a/test/unit/plugin/env-api-client.spec.js
+++ b/test/unit/plugin/env-api-client.spec.js
@@ -9,8 +9,8 @@ describe("ENV API Client Configuration plugin", () =>  {
 	describe("Load Client", () =>  {
 		it("should fail with validation error", (done) => {
 			try {
-  			const ApiConfig = require("../../../src/plugin/env-api-client");
-        const apiConfig = new ApiConfig();
+				const ApiConfig = require("../../../src/plugin/env-api-client");
+				const apiConfig = new ApiConfig();
 				done(new Error("Should have failed"));
 			} catch(err) {
 				done();
@@ -19,9 +19,9 @@ describe("ENV API Client Configuration plugin", () =>  {
 
 		it("should fail with validation error", (done) => {
 			try {
-      const options = { api: "http://somehost/v1", Token: "SOME-TOKEN"}
+			const options = { api: "http://somehost/v1", Token: "SOME-TOKEN"}
 			const ApiConfig = require("../../../src/plugin/env-api-client");
-      const apiConfig = new ApiConfig(options);
+			const apiConfig = new ApiConfig(options);
 				done(new Error("Should have failed"));
 			} catch(err) {
 				done();
@@ -29,21 +29,21 @@ describe("ENV API Client Configuration plugin", () =>  {
 		});
 
 		it("should load plugin successfully", (done) => {
-      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", timeout: 20000}
+			const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", timeout: 20000}
 			const ApiConfig = require("../../../src/plugin/env-api-client");
-      const apiConfig = new ApiConfig(options);
-      expect(apiConfig).to.exist;
-      expect(apiConfig.apiToken).to.equal("SOME-TOKEN");
-      expect(apiConfig.apiUrl).to.equal("http://somehost/v1");
-      expect(apiConfig.timeout).to.equal(20000);
+			const apiConfig = new ApiConfig(options);
+			expect(apiConfig).to.exist;
+			expect(apiConfig.apiToken).to.equal("SOME-TOKEN");
+			expect(apiConfig.apiUrl).to.equal("http://somehost/v1");
+			expect(apiConfig.timeout).to.equal(20000);
 			done();
 		});
 		it("should load plugin successfully and default timeout", (done) => {
-      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN"}
+			const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN"}
 			const ApiConfig = require("../../../src/plugin/env-api-client");
-      const apiConfig = new ApiConfig(options);
-      expect(apiConfig).to.exist;
-      expect(apiConfig.timeout).to.equal(15000);
+			const apiConfig = new ApiConfig(options);
+			expect(apiConfig).to.exist;
+			expect(apiConfig.timeout).to.equal(15000);
 			done();
 		});
 	});
@@ -55,24 +55,24 @@ describe("ENV API Client Configuration plugin", () =>  {
 				const responseOne = new Promise( (resolve, reject) => {
 					resolve(
 					{
-					  "env": {
-					    "GET_HOSTS_FROM": "dns",
-					    "MAX_RETRIES": "0",
-					    "MEMBER_HOSTS": "mongoreplica-01-svc:27017,mongoreplica-02-svc:27017,mongoreplica-03-svc:27017",
-					    "REPLICA_SET_NAME": "rs0",
-					    "WAIT_TIME": "60000"
-					  },
-					  "k8s": {
-					    "branch": "develop"
-					  }
+						"env": {
+							"GET_HOSTS_FROM": "dns",
+							"MAX_RETRIES": "0",
+							"MEMBER_HOSTS": "mongoreplica-01-svc:27017,mongoreplica-02-svc:27017,mongoreplica-03-svc:27017",
+							"REPLICA_SET_NAME": "rs0",
+							"WAIT_TIME": "60000"
+						},
+						"k8s": {
+							"branch": "develop"
+						}
 					});
 				});
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(responseOne);
 					// .onSecondCall().returns(2);
-	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", altBranch: true };
+				const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", k8sBranch: true };
 				const ApiConfig = require("../../../src/plugin/env-api-client");
-	      const apiConfig = new ApiConfig(options);
+				const apiConfig = new ApiConfig(options);
 				apiConfig.request = rp;
 
 				const service = {
@@ -83,7 +83,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 					}
 				}
 				const envs = yield apiConfig.fetch(service, "example-cluster");
-				console.log("Resolved ENVS: %j", envs);
+				// console.log("Resolved ENVS: %j", envs);
 				expect(rp.callCount).to.equal(1);
 				let calledWith = rp.getCall(0);
 				// assert that the second call was to testing branch
@@ -109,35 +109,35 @@ describe("ENV API Client Configuration plugin", () =>  {
 				const responseOne = new Promise( (resolve, reject) => {
 					resolve(
 					{
-					  "env": {
-					    "GET_HOSTS_FROM": "dns",
-					    "MAX_RETRIES": "0",
-					    "WAIT_TIME": "60000"
-					  },
-					  "k8s": {
-					    "branch": "testing"
-					  }
+						"env": {
+							"GET_HOSTS_FROM": "dns",
+							"MAX_RETRIES": "0",
+							"WAIT_TIME": "60000"
+						},
+						"k8s": {
+							"branch": "testing"
+						}
 					});
 				});
 				const responseTwo = new Promise( (resolve, reject) => {
 					resolve(
 					{
-					  "env": {
-					    "GET_HOSTS_FROM": "dns",
-					    "MAX_RETRIES": "5",
-					    "WAIT_TIME": "10000"
-					  },
-					  "k8s": {
-					    "branch": "develop"
-					  }
+						"env": {
+							"GET_HOSTS_FROM": "dns",
+							"MAX_RETRIES": "5",
+							"WAIT_TIME": "10000"
+						},
+						"k8s": {
+							"branch": "develop"
+						}
 					});
 				});
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(responseOne)
 					.onSecondCall().returns(responseTwo);
-	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", altBranch: true };
+				const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN", k8sBranch: true };
 				const ApiConfig = require("../../../src/plugin/env-api-client");
-	      const apiConfig = new ApiConfig(options);
+				const apiConfig = new ApiConfig(options);
 				apiConfig.request = rp;
 
 				const service = {
@@ -148,7 +148,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 					}
 				}
 				const envs = yield apiConfig.fetch(service, "example-cluster");
-				console.log("Resolved ENVS: %j", envs);
+				// console.log("Resolved ENVS: %j", envs);
 				expect(rp.callCount).to.equal(2);
 				let calledWith = rp.getCall(1);
 				// assert that the second call was to testing branch
@@ -165,7 +165,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 			});
 		});
 
-		it("should call request to env-api once, altbranch disabled", (done) => {
+		it("should call request to env-api once, k8sBranch disabled", (done) => {
 			Promise.coroutine(function* () {
 				// ResponseOne is returned that says use testing branch,
 				// Request is invoked again passing in branch testing
@@ -173,22 +173,22 @@ describe("ENV API Client Configuration plugin", () =>  {
 				const responseOne = new Promise( (resolve, reject) => {
 					resolve(
 					{
-					  "env": {
-					    "GET_HOSTS_FROM": "dns",
-					    "MAX_RETRIES": "0",
-					    "WAIT_TIME": "60000"
-					  },
-					  "k8s": {
-					    "branch": "testing"
-					  }
+						"env": {
+							"GET_HOSTS_FROM": "dns",
+							"MAX_RETRIES": "0",
+							"WAIT_TIME": "60000"
+						},
+						"k8s": {
+							"branch": "testing"
+						}
 					});
 				});
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(responseOne)
 					.onSecondCall().returns({});
-	      const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN" };
+				const options = { apiUrl: "http://somehost/v1", apiToken: "SOME-TOKEN" };
 				const ApiConfig = require("../../../src/plugin/env-api-client");
-	      const apiConfig = new ApiConfig(options);
+				const apiConfig = new ApiConfig(options);
 				apiConfig.request = rp;
 
 				const service = {
@@ -199,7 +199,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 					}
 				}
 				const envs = yield apiConfig.fetch(service, "example-cluster");
-				console.log("Resolved ENVS: %j", envs);
+				// console.log("Resolved ENVS: %j", envs);
 				expect(rp.callCount).to.equal(1);
 				expect(envs.branch).to.equal("testing");
 				expect(envs.env.length).to.equal(3);


### PR DESCRIPTION
# What

By setting the `altBranch: true` in the configuration of the plugin, the result of initial request to `env-api` will be queried and if a different branch is returned than current branch the `env-api` will be queried again to get the `env.yaml` values. This is a temp solution to follow the process outlined in: https://github.com/InVisionApp/engineering-notes/pull/259