### PR TITLE
Convert booleans in metadata to strings

### DIFF
--- a/src/plugin/env-api-client-v3.js
+++ b/src/plugin/env-api-client-v3.js
@@ -86,11 +86,22 @@ class EnvApiClient {
 				throw new Error("Invalid argument for 'cluster', requires cluster object not string.");
 			}
 
+			// Clean metadata so it does not have any booleans before we pass to envapi (booleans cause errors)
+			const rawMetadata = cluster.metadata();
+			const metadata = {};
+			for (const key in rawMetadata) {
+				if (typeof(rawMetadata[key]) == "boolean") {
+					metadata[key] = (rawMetadata[key]) ? "true" : "false";
+				} else {
+					metadata[key] = rawMetadata[key];
+				}
+			}
+
 			let params = {
 				service: service.annotations[EnvApiClient.annotationServiceName],
 				environment: cluster.metadata().environment,
 				cluster: cluster.name(),
-				metadata: cluster.metadata()
+				metadata: metadata
 			}
 			return this.callv3Api(params).then( (res) => {
 				if (res.status && res.status === "success") {

--- a/src/plugin/env-api-client-v3.js
+++ b/src/plugin/env-api-client-v3.js
@@ -90,8 +90,8 @@ class EnvApiClient {
 			const rawMetadata = cluster.metadata();
 			const metadata = {};
 			for (const key in rawMetadata) {
-				if (typeof(rawMetadata[key]) == "boolean") {
-					metadata[key] = (rawMetadata[key]) ? "true" : "false";
+				if (rawMetadata[key] && typeof(rawMetadata[key].toString) == "function") {
+					metadata[key] = rawMetadata[key].toString();
 				} else {
 					metadata[key] = rawMetadata[key];
 				}

--- a/test/unit/plugin/env-api-client-v3.spec.js
+++ b/test/unit/plugin/env-api-client-v3.spec.js
@@ -115,7 +115,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 			Promise.coroutine(function* () {
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(resV3Valid);
-				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com"} };
+				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com", restricted: true} };
 				const config = {kind: "ResourceConfig", env: [{name: "a", value: 1}, {name: "b", value: 2}]};
 				const clusterDef = new ClusterDefinition(cluster, config);
 
@@ -149,7 +149,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(resV3Invalid);
 				rp.onSecondCall().returns(resV2Env);
-				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com"} };
+				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com", restricted: true} };
 				const config = {kind: "ResourceConfig", env: [{name: "a", value: 1}, {name: "b", value: 2}]};
 				const clusterDef = new ClusterDefinition(cluster, config);
 
@@ -183,7 +183,7 @@ describe("ENV API Client Configuration plugin", () =>  {
 				var rp = sinon.stub();
 				rp.onFirstCall().returns(resV3Invalid);
 				rp.onSecondCall().returns(resV2Env);
-				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com"} };
+				const cluster = {kind: "ClusterNamespace", metadata: {name: "staging-cluster", type: "staging", environment: "staging", domain:"somewbesite.com", restricted: true} };
 				const config = {kind: "ResourceConfig", env: [{name: "a", value: 1}, {name: "b", value: 2}]};
 				const clusterDef = new ClusterDefinition(cluster, config);
 


### PR DESCRIPTION
# What

- we cannot send booleans to env-api or it croaks
- fix is to convert these booleans to strings before passing them to env-api