### PR TITLE
Load kubeconfig and send server to elroy

### DIFF
--- a/src/lib/cluster-definition.js
+++ b/src/lib/cluster-definition.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const _ = require("lodash");
 const resourceHandler = require("../util/resource-handler");
 
 const CLUSTER_NAMESPACE = "ClusterNamespace";
@@ -11,7 +12,7 @@ const CLUSTER_DEFINITION = "ClusterDefinition";
  * The cluster object is required, the config object is optional.
  */
 class ClusterDefinition {
-	constructor(cluster, rsConfig) {
+	constructor(cluster, rsConfig, kubeconfig) {
 		if (!cluster || cluster.kind !== CLUSTER_NAMESPACE) {
 			throw new Error("Cluster was invalid: " + ( cluster.kind || "null" ));
 		}
@@ -21,6 +22,7 @@ class ClusterDefinition {
 		this.kind = CLUSTER_DEFINITION;
 		this.cluster = cluster;
 		this.rsConfig = ( rsConfig || { kind: RESOURCE_CONFIG } );
+		this.kubeconfig = kubeconfig;
 	}
 
 	/**
@@ -92,6 +94,17 @@ class ClusterDefinition {
 	 */
 	configuration() {
 		return this.rsConfig;
+	}
+	
+	/**
+	 * Server url for cluster
+	 * @return {string} Url configured in kubeconfig
+	 */
+	get server() {
+		if (_.has(this.kubeconfig, ["clusters", 0, "cluster", "server"])) {
+			return this.kubeconfig.clusters[0].cluster.server;
+		}
+		return null;
 	}
 
 	/**

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -207,7 +207,8 @@ class Deploymentizer {
 				kubernetes: {
 					cluster: def.cluster.metadata.cluster,
 					namespace: def.cluster.metadata.namespace,
-					ingress: (def["ingress-controller"] || null)
+					ingress: (def["ingress-controller"] || null),
+					server: def.server
 				},
 				resources: {}
 			};

--- a/src/util/yaml-handler.js
+++ b/src/util/yaml-handler.js
@@ -110,7 +110,8 @@ class YamlHandler {
 				if ( exists ) {
           const cluster = yield YamlHandler.loadFile(path.join(basePath, dir, "cluster.yaml"));
 					const config = yield YamlHandler.loadFile(path.join(basePath, dir, "configuration-var.yaml"));
-					clusters.push( new ClusterDefinition( cluster, config ) );
+					const kubeconfig = yield YamlHandler.loadFile(path.join(basePath, dir, "kubeconfig.yaml"));
+					clusters.push( new ClusterDefinition(cluster, config, kubeconfig) );
 				} else {
 					logger.debug(`No Cluster file found for ${dir}, skipping...`);
 				}

--- a/test/fixture/clusters/disabled-cluster/kubeconfig.yaml
+++ b/test/fixture/clusters/disabled-cluster/kubeconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../../keys/disabled-test-fixture/ca.pem
+    server: https://disabled-test-fixture.k8s-controller.example.com
+  name: kube-aws-cluster
+contexts:
+- context:
+    cluster: kube-aws-cluster
+    namespace: default
+    user: kube-aws-cluster-admin
+  name: kube-aws-cluster-context
+current-context: kube-aws-cluster-context
+kind: Config
+metadata:
+  name: disabled-test-fixture-cluster
+users:
+- name: kube-aws-cluster-admin
+  user:
+    client-certificate: ../../keys/disabled-test-fixture/admin.pem
+    client-key: ../../keys/disabled-test-fixture/admin-key.pem

--- a/test/fixture/clusters/failure-cluster/kubeconfig.yaml
+++ b/test/fixture/clusters/failure-cluster/kubeconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../../keys/failure-fixture/ca.pem
+    server: https://failure-fixture.k8s-controller.example.com
+  name: kube-aws-cluster
+contexts:
+- context:
+    cluster: kube-aws-cluster
+    namespace: default
+    user: kube-aws-cluster-admin
+  name: kube-aws-cluster-context
+current-context: kube-aws-cluster-context
+kind: Config
+metadata:
+  name: failure-fixture-cluster
+users:
+- name: kube-aws-cluster-admin
+  user:
+    client-certificate: ../../keys/failure-fixture/admin.pem
+    client-key: ../../keys/failure-fixture/admin-key.pem

--- a/test/fixture/clusters/other-cluster/kubeconfig.yaml
+++ b/test/fixture/clusters/other-cluster/kubeconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../../keys/other-test-fixture/ca.pem
+    server: https://other-test-fixture.k8s-controller.example.com
+  name: kube-aws-cluster
+contexts:
+- context:
+    cluster: kube-aws-cluster
+    namespace: default
+    user: kube-aws-cluster-admin
+  name: kube-aws-cluster-context
+current-context: kube-aws-cluster-context
+kind: Config
+metadata:
+  name: other-test-fixture-cluster
+users:
+- name: kube-aws-cluster-admin
+  user:
+    client-certificate: ../../keys/other-test-fixture/admin.pem
+    client-key: ../../keys/other-test-fixture/admin-key.pem

--- a/test/fixture/clusters/test-cluster/kubeconfig.yaml
+++ b/test/fixture/clusters/test-cluster/kubeconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../../keys/test-fixture/ca.pem
+    server: https://test-fixture.k8s-controller.example.com
+  name: kube-aws-cluster
+contexts:
+- context:
+    cluster: kube-aws-cluster
+    namespace: default
+    user: kube-aws-cluster-admin
+  name: kube-aws-cluster-context
+current-context: kube-aws-cluster-context
+kind: Config
+metadata:
+  name: test-fixture-cluster
+users:
+- name: kube-aws-cluster-admin
+  user:
+    client-certificate: ../../keys/test-fixture/admin.pem
+    client-key: ../../keys/test-fixture/admin-key.pem

--- a/test/fixture/empty-clusters/empty-cluster/kubeconfig.yaml
+++ b/test/fixture/empty-clusters/empty-cluster/kubeconfig.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: ../../keys/empty-test-fixture/ca.pem
+    server: https://empty-test-fixture.k8s-controller.example.com
+  name: kube-aws-cluster
+contexts:
+- context:
+    cluster: kube-aws-cluster
+    namespace: default
+    user: kube-aws-cluster-admin
+  name: kube-aws-cluster-context
+current-context: kube-aws-cluster-context
+kind: Config
+metadata:
+  name: empty-test-fixture-cluster
+users:
+- name: kube-aws-cluster-admin
+  user:
+    client-certificate: ../../keys/empty-test-fixture/admin.pem
+    client-key: ../../keys/empty-test-fixture/admin-key.pem

--- a/test/unit/lib/cluster-definition.spec.js
+++ b/test/unit/lib/cluster-definition.spec.js
@@ -87,6 +87,7 @@ describe("Cluster Definitions", () =>  {
 				expect(clusterDef).to.exist;
 				expect(clusterDef.name()).to.equal("test-fixture");
 				expect(clusterDef.type()).to.equal("test");
+				expect(clusterDef.server).to.equal("https://test-fixture.k8s-controller.example.com");
 				expect(clusterDef.rsConfig.deployment).to.exist;
 				expect(clusterDef.rsConfig.deployment.replicaCount).to.equal(2);
 				done()
@@ -106,6 +107,7 @@ describe("Cluster Definitions", () =>  {
 				const clusterDef = clusterDefs[3];
 				expect(clusterDef).to.exist;
 				expect(clusterDef.name()).to.equal("test-fixture");
+				expect(clusterDef.server).to.equal("https://test-fixture.k8s-controller.example.com");
 				expect(clusterDef.rsConfig.deployment).to.exist;
 				expect(clusterDef.rsConfig.deployment.replicaCount).to.equal(2);
 				expect(clusterDef.rsConfig.deployment.imagePullPolicy).to.not.exist;


### PR DESCRIPTION
# What

- deploymentizer will now also require and load the `kubeconfig.yaml` file
- will send the `server` definition in the `kubeconfig` to elroy