### PR TITLE
fix: store resourceconfig as object in elroy

### DIFF
--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -202,7 +202,7 @@ class Deploymentizer {
 					cluster: def.cluster.metadata.cluster,
 					namespace: def.cluster.metadata.namespace,
 					server: def.server,
-					resourceConfig: JSON.stringify(def.rsConfig)
+					resourceConfig: def.rsConfig
 				},
 				resources: {}
 			};


### PR DESCRIPTION
Ref InVisionApp/elroy#118

We decided to store it as a `map[string]interface{}`.