### PR TITLE
append the sha as  a label to deployments

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -7,6 +7,7 @@ app:
   volumes:
     - example:/example
     - test:/test
+    #- generated:/generated
 publish:
   image: quay.io/invision/docker-node-publisher:v1
   encrypted_env_file: codeship-publish.env.encrypted

--- a/src/deploymentizer
+++ b/src/deploymentizer
@@ -57,6 +57,7 @@ program
 	.option("-d, --debug <boolean>", "Sets debug flag", parseBoolean, parseBoolean(process.env.DEBUG))
 	.option("-r, --resource <string>", "Sets the resource to generate", process.env.RESOURCE)
 	.option("-t, --clusterType <string>", "Sets the cluster type to generate. Cannot be used with clusterName.", process.env.CLUSTER_TYPE)
+	.option("--sha <string>", "Sets the commit SHA to use. Can only be used for single Resource", process.env.SHA)
 	.option("--clusterName <string>", "Sets the name of the cluster to generate. Cannot be used with clusterType.", process.env.CLUSTER_NAME)
 	.option("--elroyOnly <boolean>", "When enabled it will only generate what it needs to do an Elroy update", parseBoolean, parseBoolean(process.env.ELROY_ONLY))
 	.option("--elroyUrl <string>", "Set to an Elroy URL where you want the generated cluster information sent", process.env.ELROY_URL)
@@ -80,7 +81,8 @@ loadConf(program.conf).then( (conf) => {
 		conf: conf,
 		resource: program.resource,
 		clusterType: program.clusterType,
-		clusterName: program.clusterName
+		clusterName: program.clusterName,
+		sha: program.sha
 	});
 	// Enable logging of all events from the deploymentizer
 	deploymentizer.events.on(deploymentizer.events.INFO, function(message) {

--- a/src/deploymentizer
+++ b/src/deploymentizer
@@ -57,7 +57,7 @@ program
 	.option("-d, --debug <boolean>", "Sets debug flag", parseBoolean, parseBoolean(process.env.DEBUG))
 	.option("-r, --resource <string>", "Sets the resource to generate", process.env.RESOURCE)
 	.option("-t, --clusterType <string>", "Sets the cluster type to generate. Cannot be used with clusterName.", process.env.CLUSTER_TYPE)
-	.option("--sha <string>", "Sets the commit SHA to use. Can only be used for single Resource", process.env.SHA)
+	.option("--id <string>", "Sets the deployment id to use. Can only be used for single Resource", process.env.ID)
 	.option("--fastRollback <boolean>", "When enabled it will configure fastrollback support via Service generation", parseBoolean, parseBoolean(process.env.FAST_ROLLBACK))
 	.option("--clusterName <string>", "Sets the name of the cluster to generate. Cannot be used with clusterType.", process.env.CLUSTER_NAME)
 	.option("--elroyOnly <boolean>", "When enabled it will only generate what it needs to do an Elroy update", parseBoolean, parseBoolean(process.env.ELROY_ONLY))
@@ -83,7 +83,7 @@ loadConf(program.conf).then( (conf) => {
 		resource: program.resource,
 		clusterType: program.clusterType,
 		clusterName: program.clusterName,
-		sha: program.sha,
+		id: program.id,
 		fastRollback: program.fastRollback
 	});
 	// Enable logging of all events from the deploymentizer

--- a/src/deploymentizer
+++ b/src/deploymentizer
@@ -58,6 +58,7 @@ program
 	.option("-r, --resource <string>", "Sets the resource to generate", process.env.RESOURCE)
 	.option("-t, --clusterType <string>", "Sets the cluster type to generate. Cannot be used with clusterName.", process.env.CLUSTER_TYPE)
 	.option("--sha <string>", "Sets the commit SHA to use. Can only be used for single Resource", process.env.SHA)
+	.option("--fastRollback <boolean>", "When enabled it will configure fastrollback support via Service generation", parseBoolean, parseBoolean(process.env.FAST_ROLLBACK))
 	.option("--clusterName <string>", "Sets the name of the cluster to generate. Cannot be used with clusterType.", process.env.CLUSTER_NAME)
 	.option("--elroyOnly <boolean>", "When enabled it will only generate what it needs to do an Elroy update", parseBoolean, parseBoolean(process.env.ELROY_ONLY))
 	.option("--elroyUrl <string>", "Set to an Elroy URL where you want the generated cluster information sent", process.env.ELROY_URL)
@@ -82,7 +83,8 @@ loadConf(program.conf).then( (conf) => {
 		resource: program.resource,
 		clusterType: program.clusterType,
 		clusterName: program.clusterName,
-		sha: program.sha
+		sha: program.sha,
+		fastRollback: program.fastRollback
 	});
 	// Enable logging of all events from the deploymentizer
 	deploymentizer.events.on(deploymentizer.events.INFO, function(message) {

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -47,7 +47,7 @@ class Deploymentizer {
 			resource: (args.resource || undefined),
 			clusterType: (args.clusterType || undefined),
 			clusterName: (args.clusterName || undefined),
-			sha: (args.sha || undefined),
+			id: (args.id || undefined),
 			fastRollback: (args.fastRollback || false)
 		};
 		this.options.conf = this.parseConf(args.conf);
@@ -65,11 +65,11 @@ class Deploymentizer {
 				throw new Error("You cannot set both clusterName and clusterType at the same time");
 			}
 
-			if (this.options.sha && !this.options.resource) {
-				throw new Error("You must include the resource if deploying a specific SHA");
+			if (this.options.id && !this.options.resource) {
+				throw new Error("You must include the resource if deploying a specific id");
 			}
-			if (this.options.fastRollback && !this.options.sha) {
-				throw new Error("You must include the sha if configuring fastRollbacks");
+			if (this.options.fastRollback && !this.options.id) {
+				throw new Error("You must include the id if configuring fastRollbacks");
 			}
 			if (this.options.clusterName) {
 				this.events.emitInfo(`Running for cluster ${this.options.clusterName} and resource ${this.options.resource || "all"}`);
@@ -188,7 +188,7 @@ class Deploymentizer {
 																				configPlugin,
 																				this.options.resource,
 																				this.events,
-																				this.options.sha,
+																				this.options.id,
 																				this.options.fastRollback);
 				return Promise.all([elroyProm, generator.process()]);
 			};
@@ -221,7 +221,7 @@ class Deploymentizer {
 				// Only include the resource if it's NOT disabled
 				if (!resource.disable) {
 					cluster.resources[name] = {
-						sha: "",
+						id: "",
 						deploymentId: "",
 						config: null
 					};

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -47,7 +47,8 @@ class Deploymentizer {
 			resource: (args.resource || undefined),
 			clusterType: (args.clusterType || undefined),
 			clusterName: (args.clusterName || undefined),
-			sha: (args.sha || undefined)
+			sha: (args.sha || undefined),
+			fastRollback: (args.fastRollback || false)
 		};
 		this.options.conf = this.parseConf(args.conf);
 		this.events = new EventHandler();
@@ -66,6 +67,9 @@ class Deploymentizer {
 
 			if (this.options.sha && !this.options.resource) {
 				throw new Error("You must include the resource if deploying a specific SHA");
+			}
+			if (this.options.fastRollback && !this.options.sha) {
+				throw new Error("You must include the sha if configuring fastRollbacks");
 			}
 			if (this.options.clusterName) {
 				this.events.emitInfo(`Running for cluster ${this.options.clusterName} and resource ${this.options.resource || "all"}`);
@@ -184,7 +188,8 @@ class Deploymentizer {
 																				configPlugin,
 																				this.options.resource,
 																				this.events,
-																				this.options.sha);
+																				this.options.sha,
+																				this.options.fastRollback);
 				return Promise.all([elroyProm, generator.process()]);
 			};
 		});

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -47,10 +47,10 @@ class Generator {
 	 * @param	{[type]} configPlugin			Plugin to use for loading configuration information
 	 * @param	{[type]} resource 				resource to process
 	 * @param	{[type]} eventHandler 		to log events to
-	 * @param	{[type]} sha							sha to use when generating manifests, switch to uuid from elroy
+	 * @param	{[type]} id								id to use when generating manifests, switch to uuid from elroy
 	 * @param	{[type]} fastRollback			determines if fastRollback support is enabled. used by manifest generation
 	 */
-	constructor(clusterDef, imageResourceDefs, basePath, exportPath, save, configPlugin, resource, eventHandler, sha, fastRollback) {
+	constructor(clusterDef, imageResourceDefs, basePath, exportPath, save, configPlugin, resource, eventHandler, id, fastRollback) {
 		this.options = {
 			clusterDef: clusterDef,
 			imageResourceDefs: imageResourceDefs,
@@ -58,7 +58,7 @@ class Generator {
 			exportPath: path.join(exportPath, clusterDef.name()),
 			save: (save || false),
 			resource: (resource || undefined),
-			sha: (sha || undefined),
+			id: (id || undefined),
 			fastRollback: (fastRollback || false)
 		};
 		this.configPlugin = configPlugin;
@@ -159,8 +159,8 @@ class Generator {
 			localConfig.branch = (resource.branch || this.options.clusterDef.branch());
 			// Add the ResourceName to the config object.
 			localConfig.name = resourceName;
-			if (this.options.sha) {
-				localConfig.deployment = {sha: this.options.sha, fastRollback: this.options.fastRollback}
+			if (this.options.id) {
+				localConfig.deployment = {id: this.options.id, fastRollback: this.options.fastRollback}
 			}
 
 			// Map all containers into an Array

--- a/test/fixture/resources/activity/activity-deployment.mustache
+++ b/test/fixture/resources/activity/activity-deployment.mustache
@@ -9,9 +9,9 @@ metadata:
     tier: frontend
     tech: nodejs
     release: dev
-    {{#deployment.sha}}
-    sha: {{{deployment.sha}}}
-    {{/deployment.sha}}
+    {{#deployment.id}}
+    id: {{{deployment.id}}}
+    {{/deployment.id}}
     service: {{{name}}}
 spec:
   template:

--- a/test/fixture/resources/activity/activity-deployment.mustache
+++ b/test/fixture/resources/activity/activity-deployment.mustache
@@ -1,7 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  {{#deployment.sha}}
+  name: {{{name}}}-deployment-{{{deployment.sha}}}
+  {{/deployment.sha}}
+  {{^deployment.sha}}
   name: {{{name}}}-deployment
+  {{/deployment.sha}}
   annotations:
     kit-deployer/dependency-selector: 'tier=backend,tier=config'
   labels:
@@ -9,6 +14,8 @@ metadata:
     tier: frontend
     tech: nodejs
     release: dev
+    sha: {{{deployment.sha}}}
+    service: {{{name}}}
 spec:
   template:
     spec:
@@ -45,3 +52,4 @@ spec:
   selector:
     matchLabels:
       name: {{{name}}}-pod
+      state: live

--- a/test/fixture/resources/activity/activity-deployment.mustache
+++ b/test/fixture/resources/activity/activity-deployment.mustache
@@ -1,12 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  {{#deployment.sha}}
-  name: {{{name}}}-deployment-{{{deployment.sha}}}
-  {{/deployment.sha}}
-  {{^deployment.sha}}
   name: {{{name}}}-deployment
-  {{/deployment.sha}}
   annotations:
     kit-deployer/dependency-selector: 'tier=backend,tier=config'
   labels:
@@ -14,7 +9,9 @@ metadata:
     tier: frontend
     tech: nodejs
     release: dev
+    {{#deployment.sha}}
     sha: {{{deployment.sha}}}
+    {{/deployment.sha}}
     service: {{{name}}}
 spec:
   template:
@@ -52,4 +49,3 @@ spec:
   selector:
     matchLabels:
       name: {{{name}}}-pod
-      state: live

--- a/test/fixture/resources/auth/auth-deployment.mustache
+++ b/test/fixture/resources/auth/auth-deployment.mustache
@@ -9,9 +9,9 @@ metadata:
     tier: frontend
     tech: nodejs
     release: stable
-    {{#deployment.sha}}
-    sha: {{{deployment.sha}}}
-    {{/deployment.sha}}
+    {{#deployment.id}}
+    id: {{{deployment.id}}}
+    {{/deployment.id}}
     service: {{{name}}}
 spec:
   template:

--- a/test/fixture/resources/auth/auth-deployment.mustache
+++ b/test/fixture/resources/auth/auth-deployment.mustache
@@ -1,12 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  {{#deployment.sha}}
-  name: {{{name}}}-deployment-{{{deployment.sha}}}
-  {{/deployment.sha}}
-  {{^deployment.sha}}
   name: {{{name}}}-deployment
-  {{/deployment.sha}}
   annotations:
     kit-deployer/dependency-selector: 'tier=backend'
   labels:
@@ -14,7 +9,9 @@ metadata:
     tier: frontend
     tech: nodejs
     release: stable
+    {{#deployment.sha}}
     sha: {{{deployment.sha}}}
+    {{/deployment.sha}}
     service: {{{name}}}
 spec:
   template:

--- a/test/fixture/resources/auth/auth-deployment.mustache
+++ b/test/fixture/resources/auth/auth-deployment.mustache
@@ -1,7 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  {{#deployment.sha}}
+  name: {{{name}}}-deployment-{{{deployment.sha}}}
+  {{/deployment.sha}}
+  {{^deployment.sha}}
   name: {{{name}}}-deployment
+  {{/deployment.sha}}
   annotations:
     kit-deployer/dependency-selector: 'tier=backend'
   labels:
@@ -9,6 +14,8 @@ metadata:
     tier: frontend
     tech: nodejs
     release: stable
+    sha: {{{deployment.sha}}}
+    service: {{{name}}}
 spec:
   template:
     spec:

--- a/test/fixture/resources/base-svc.mustache
+++ b/test/fixture/resources/base-svc.mustache
@@ -6,3 +6,8 @@ metadata:
   {{#svc.labels}}
     {{{name}}}: {{{value}}}
   {{/svc.labels}}
+  {{#deployment.fastRollback}}
+    {{#deployment.sha}}
+    sha: {{{deployment.sha}}}
+    {{/deployment.sha}}
+  {{/deployment.fastRollback}}

--- a/test/fixture/resources/base-svc.mustache
+++ b/test/fixture/resources/base-svc.mustache
@@ -7,7 +7,7 @@ metadata:
     {{{name}}}: {{{value}}}
   {{/svc.labels}}
   {{#deployment.fastRollback}}
-    {{#deployment.sha}}
-    sha: {{{deployment.sha}}}
-    {{/deployment.sha}}
+    {{#deployment.id}}
+    id: {{{deployment.id}}}
+    {{/deployment.id}}
   {{/deployment.fastRollback}}

--- a/test/functional/lib/deploymentizer.spec.js
+++ b/test/functional/lib/deploymentizer.spec.js
@@ -64,12 +64,14 @@ describe("Deploymentizer", () => {
 				expect(authSvc.metadata.name).to.equal("auth-svc");
 				expect(authSvc.metadata.labels.app).to.exist;
 				expect(authSvc.metadata.labels.app).to.equal("invisionapp");
+				console.log("\n\n\n\n " + typeof authSvc.metadata.labels.sha)
+				expect(typeof authSvc.metadata.labels.sha === "undefined").to.equal(true)
 
 				const auth = yield yamlHandler.loadFile(path.join(os.tmpdir(), "generated", "test-fixture", "auth-deployment.yaml"));
 				expect(auth).to.exist;
 				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
-				expect(auth.metadata.labels.sha).to.be.null;
+				expect(typeof auth.metadata.labels.sha === "undefined").to.equal(true)
 				expect(auth.spec.template.spec.imagePullSecrets).to.include({"name": "docker-quay-secret"});
 				expect(auth.spec.replicas).to.equal(2);
 				expect(auth.spec.strategy).to.exist;
@@ -118,7 +120,8 @@ describe("Deploymentizer", () => {
 					save: true,
 					conf: conf,
 					sha: "SOME-SHA",
-					resource: "auth"
+					resource: "auth",
+					fastRollback: true
 				});
 				// multiple events will get fired for failure cluster.
 				deployer.events.on(deployer.events.WARN, function(message) {
@@ -134,10 +137,12 @@ describe("Deploymentizer", () => {
 				expect(authSvc.metadata.name).to.equal("auth-svc");
 				expect(authSvc.metadata.labels.app).to.exist;
 				expect(authSvc.metadata.labels.app).to.equal("invisionapp");
+				expect(authSvc.metadata.labels.sha).to.exist;
+				expect(authSvc.metadata.labels.sha).to.equal("SOME-SHA");
 
 				const auth = yield yamlHandler.loadFile(path.join(os.tmpdir(), "generated", "test-fixture", "auth-deployment.yaml"));
 				expect(auth).to.exist;
-				expect(auth.metadata.name).to.equal("auth-deployment-SOME-SHA");
+				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
 				expect(auth.metadata.labels.sha).to.equal("SOME-SHA");
 				expect(auth.spec.strategy).to.exist;

--- a/test/functional/lib/deploymentizer.spec.js
+++ b/test/functional/lib/deploymentizer.spec.js
@@ -35,7 +35,7 @@ describe("Deploymentizer", () => {
 	});
 
 	describe("generate files", () => {
-		it("should run successfully without sha", (done) => {
+		it("should run successfully without id", (done) => {
 			Promise.coroutine(function* () {
 				process.env.SECRET_USERNAME = "myusername";
 				process.env.SECRET_PASSWORD = "mypassword";
@@ -64,14 +64,14 @@ describe("Deploymentizer", () => {
 				expect(authSvc.metadata.name).to.equal("auth-svc");
 				expect(authSvc.metadata.labels.app).to.exist;
 				expect(authSvc.metadata.labels.app).to.equal("invisionapp");
-				console.log("\n\n\n\n " + typeof authSvc.metadata.labels.sha)
-				expect(typeof authSvc.metadata.labels.sha === "undefined").to.equal(true)
+				console.log("\n\n\n\n " + typeof authSvc.metadata.labels.id)
+				expect(typeof authSvc.metadata.labels.id === "undefined").to.equal(true)
 
 				const auth = yield yamlHandler.loadFile(path.join(os.tmpdir(), "generated", "test-fixture", "auth-deployment.yaml"));
 				expect(auth).to.exist;
 				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
-				expect(typeof auth.metadata.labels.sha === "undefined").to.equal(true)
+				expect(typeof auth.metadata.labels.id === "undefined").to.equal(true)
 				expect(auth.spec.template.spec.imagePullSecrets).to.include({"name": "docker-quay-secret"});
 				expect(auth.spec.replicas).to.equal(2);
 				expect(auth.spec.strategy).to.exist;
@@ -105,7 +105,7 @@ describe("Deploymentizer", () => {
 			});
 		});
 
-		it("should run successfully with sha", (done) => {
+		it("should run successfully with id", (done) => {
 			Promise.coroutine(function* () {
 				process.env.SECRET_USERNAME = "myusername";
 				process.env.SECRET_PASSWORD = "mypassword";
@@ -119,7 +119,7 @@ describe("Deploymentizer", () => {
 					clean: true,
 					save: true,
 					conf: conf,
-					sha: "SOME-SHA",
+					id: "SOME-SHA",
 					resource: "auth",
 					fastRollback: true
 				});
@@ -137,14 +137,14 @@ describe("Deploymentizer", () => {
 				expect(authSvc.metadata.name).to.equal("auth-svc");
 				expect(authSvc.metadata.labels.app).to.exist;
 				expect(authSvc.metadata.labels.app).to.equal("invisionapp");
-				expect(authSvc.metadata.labels.sha).to.exist;
-				expect(authSvc.metadata.labels.sha).to.equal("SOME-SHA");
+				expect(authSvc.metadata.labels.id).to.exist;
+				expect(authSvc.metadata.labels.id).to.equal("SOME-SHA");
 
 				const auth = yield yamlHandler.loadFile(path.join(os.tmpdir(), "generated", "test-fixture", "auth-deployment.yaml"));
 				expect(auth).to.exist;
 				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
-				expect(auth.metadata.labels.sha).to.equal("SOME-SHA");
+				expect(auth.metadata.labels.id).to.equal("SOME-SHA");
 				expect(auth.spec.strategy).to.exist;
 
 				done();
@@ -153,7 +153,7 @@ describe("Deploymentizer", () => {
 			});
 		});
 
-		it("should run successfully with sha but no fastRollback", (done) => {
+		it("should run successfully with id but no fastRollback", (done) => {
 			Promise.coroutine(function* () {
 				process.env.SECRET_USERNAME = "myusername";
 				process.env.SECRET_PASSWORD = "mypassword";
@@ -168,7 +168,7 @@ describe("Deploymentizer", () => {
 					save: true,
 					conf: conf,
 					resource: "auth",
-					sha: "SOME-SHA"
+					id: "SOME-SHA"
 				});
 				// multiple events will get fired for failure cluster.
 				deployer.events.on(deployer.events.WARN, function(message) {
@@ -184,13 +184,13 @@ describe("Deploymentizer", () => {
 				expect(authSvc.metadata.name).to.equal("auth-svc");
 				expect(authSvc.metadata.labels.app).to.exist;
 				expect(authSvc.metadata.labels.app).to.equal("invisionapp");
-				expect(typeof authSvc.metadata.labels.sha === "undefined").to.equal(true)
+				expect(typeof authSvc.metadata.labels.id === "undefined").to.equal(true)
 
 				const auth = yield yamlHandler.loadFile(path.join(os.tmpdir(), "generated", "test-fixture", "auth-deployment.yaml"));
 				expect(auth).to.exist;
 				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
-				expect(auth.metadata.labels.sha).to.equal("SOME-SHA");
+				expect(auth.metadata.labels.id).to.equal("SOME-SHA");
 				expect(auth.spec.strategy).to.exist;
 
 				done();


### PR DESCRIPTION
# What

This will take the supplied sha and append it to the manifest as a label. Also, validates that the service name is already available for templates. Also addes fastRollback value to mustache templates that can be used to add SHA to a `$service-svc` selector label. 

This PR adds the following values to the injected data for rendering a mustache template:
```
deployment.sha
deployment.fastRollback
```
_fastRollback_ is a boolean indicating the template service should be rendered with the the SHA as part of the selector.
_sha_ is the commit deployment sha and is used for matching a deployment to a service.

NOTE: when updating the k8s service object, make sure both fastRollback and sha are populated before rendering the selector label. 
https://github.com/InVisionApp/kit-deploymentizer/pull/47/files#diff-336cf2cf5e97eb91fb7d6b66a2b44349R9

This is required for #44 and #43 

