### PR TITLE
deployment object may already exist

### DIFF
--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -160,7 +160,12 @@ class Generator {
 			// Add the ResourceName to the config object.
 			localConfig.name = resourceName;
 			if (this.options.deployId) {
-				localConfig.deployment = {id: this.options.deployId, fastRollback: this.options.fastRollback}
+				if (localConfig.deployment) {
+					localConfig.deployment.id = this.options.deployId
+					localConfig.deployment.fastRollback= this.options.fastRollback
+				} else {
+					localConfig.deployment = {id: this.options.deployId, fastRollback: this.options.fastRollback}
+				}
 			}
 
 			// Map all containers into an Array

--- a/test/functional/lib/deploymentizer.spec.js
+++ b/test/functional/lib/deploymentizer.spec.js
@@ -192,7 +192,6 @@ describe("Deploymentizer", () => {
 				expect(auth.metadata.labels.id).to.equal("SOME-SHA");
 				expect(auth.spec.replicas).to.equal(2);
 				expect(auth.spec.strategy).to.exist;
-				console.log("\n\n AuthSpec: " + JSON.stringify(auth))
 
 				done();
 			})().catch( (err) => {

--- a/test/functional/lib/deploymentizer.spec.js
+++ b/test/functional/lib/deploymentizer.spec.js
@@ -190,7 +190,9 @@ describe("Deploymentizer", () => {
 				expect(auth.metadata.name).to.equal("auth-deployment");
 				expect(auth.metadata.labels.service).to.equal("auth");
 				expect(auth.metadata.labels.id).to.equal("SOME-SHA");
+				expect(auth.spec.replicas).to.equal(2);
 				expect(auth.spec.strategy).to.exist;
+				console.log("\n\n AuthSpec: " + JSON.stringify(auth))
 
 				done();
 			})().catch( (err) => {


### PR DESCRIPTION
If the `deployment` object on the `localConfig` already exists we append the new values. Otherwise, we create a new deployment object with the required values.