### PR TITLE
minor: Disable removed clusters-only send empty config

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "./src/index.js",
   "bin": "./src/deploymentizer",
   "scripts": {
-    "test-unit": "mocha --recursive test/unit",
+    "test-unit": "mocha --recursive test/unit --timeout 15000",
     "test-functional": "mocha --recursive test/functional",
     "test": "mocha --recursive test",
     "lint": "eslint src test",
@@ -46,7 +46,8 @@
     "eslint": "4.4.1",
     "eslint-config-prettier": "2.3.0",
     "eslint-plugin-prettier": "2.1.2",
-    "prettier": "1.5.3"
+    "prettier": "1.5.3",
+    "mockery": "2.1.0"
   },
   "files": ["LICENSE", "src"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "./src/index.js",
   "bin": "./src/deploymentizer",
   "scripts": {
-    "test-unit": "mocha --recursive test/unit --timeout 15000",
+    "test-unit": "mocha --recursive test/unit",
     "test-functional": "mocha --recursive test/functional",
     "test": "mocha --recursive test",
     "lint": "eslint src test",

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -278,11 +278,10 @@ class Deploymentizer {
       // Populate resources in new format
       _.each(def.cluster.resources, (resource, name) => {
         // Only include the resource if it's NOT disabled
+        // TODO: include resource data in config
         if (!resource.disable) {
           cluster.resources[name] = {
-            id: "",
-            deploymentId: "",
-            config: null
+            config: {}
           };
         }
       });

--- a/src/lib/elroy-sync.js
+++ b/src/lib/elroy-sync.js
@@ -1,0 +1,168 @@
+"use strict";
+
+const _ = require("lodash");
+const request = require("request-promise");
+const errors = require("request-promise/errors");
+const Promise = require("bluebird");
+
+const MaxCount = 300;
+
+/**
+ * Handles Syncing Clusters to Elroy
+ */
+class ElroySync {
+  /**
+	 * Deactivates Clusters that are in elroy but no longer in cluster definitions
+	 * @param {*} clusterDefs Array of cluster definitions
+	 * @param {*} events 			Eventhandler to send events to
+	 * @param {*} options     Elroy connection information
+	 */
+  static RemoveDeploymentEnvironments(clusterDefs, events, options) {
+    events.emitDebug(`Getting list of DeploymentEnvironments from Elroy...`);
+    const _self = this;
+    const req = {
+      uri: options.elroyUrl + "/api/v1/deployment-environment",
+      headers: {
+        "X-Auth-Token": options.elroySecret
+      },
+      qs: {
+        limit: MaxCount
+      },
+      json: true
+    };
+    return request(req)
+      .then(res => {
+        if (res.count > MaxCount) {
+          events.emitFatal(
+            `DeploymentEnvironments returned to many Environments: ${res.count}`
+          );
+        }
+        let toDeactivate = [];
+        res.items.forEach(function(deployEnv) {
+          let found = _.some(clusterDefs, [
+            "cluster.metadata.name",
+            deployEnv.name
+          ]);
+          // If we dont find it in the cluster defs and it is active, deactivate it
+          if (!found && deployEnv.active) {
+            events.emitInfo(`Deactivating Cluster ${deployEnv.name}`);
+            deployEnv.active = false;
+            toDeactivate.push(_self.updateCluster(deployEnv, events, options));
+          }
+        });
+        events.emitInfo(`Cluster count deactivated: ${toDeactivate.length}`);
+        return Promise.all(toDeactivate);
+      })
+      .catch(err => {
+        throw err;
+      });
+  }
+
+  /**
+	 * Saves the given cluster definition to an external Elroy instance. Returns a promise that is resolved on success.
+	 *
+	 * @param {[type]} def          Cluster Definition
+	 */
+  static SaveToElroy(def, events, options, retryCount) {
+    const _self = this;
+    return Promise.try(() => {
+      // Format for elroy
+      const cluster = {
+        name: def.cluster.metadata.name,
+        tier: def.cluster.metadata.type,
+        active: def.cluster.metadata.active || true, // Clusters are active by default
+        metadata: def.cluster.metadata,
+        kubernetes: {
+          cluster: def.cluster.metadata.cluster,
+          namespace: def.cluster.metadata.namespace,
+          server: def.server,
+          resourceConfig: def.rsConfig
+        },
+        resources: {}
+      };
+      // Populate resources in new format
+      _.each(def.cluster.resources, (resource, name) => {
+        // Only include the resource if it's NOT disabled
+        // TODO: include resource data in config
+        if (!resource.disable) {
+          cluster.resources[name] = {
+            config: {}
+          };
+        }
+      });
+      events.emitDebug(`Saving Cluster ${cluster.name} to Elroy...`);
+      return _self.createCluster(cluster, events, options).catch(reason => {
+        if (reason.response && reason.response.statusCode) {
+          // If error is because it already exists, lets do an update
+          if (reason.response.statusCode == 409) {
+            return _self.updateCluster(cluster, events, options);
+          }
+          // validation problem , ie the tier doesn't exists
+          if (reason.response.statusCode == 404) {
+            events.emitDebug(
+              `Problem syncing the cluster ${cluster.name} with tier ${cluster.tier} to Elroy: 404`
+            );
+            return;
+          }
+          if (!retryCount) {
+            retryCount = 0;
+          }
+          if (reason.response.statusCode == 504 && retryCount < 3) {
+            retryCount++;
+            events.emitWarn(
+              `Problem syncing the cluster ${cluster.name} with tier ${cluster.tier} to Elroy: 504, retrying ${retryCount}`
+            );
+            return Promise.delay(500).then(() => {
+              return _self.SaveToElroy(def, events, options, retryCount);
+            });
+          }
+        }
+        events.emitWarn(
+          `Error adding Cluster ${cluster.name} to Elroy: ${reason}`
+        );
+        throw reason;
+      });
+    });
+  }
+
+  static createCluster(cluster, events, options) {
+    return request({
+      simple: true,
+      method: "POST",
+      uri: options.elroyUrl + "/api/v1/deployment-environment",
+      headers: {
+        "X-Auth-Token": options.elroySecret
+      },
+      body: cluster,
+      json: true
+    }).then(res => {
+      events.emitDebug(`Successfully added Cluster ${cluster.name} to Elroy`);
+      return res;
+    });
+  }
+
+  static updateCluster(cluster, events, options) {
+    return request({
+      method: "PUT",
+      uri: options.elroyUrl + "/api/v1/deployment-environment/" + cluster.name,
+      headers: {
+        "X-Auth-Token": options.elroySecret
+      },
+      body: cluster,
+      json: true
+    })
+      .then(res => {
+        events.emitDebug(
+          `Successfully updated Cluster ${cluster.name} to Elroy`
+        );
+        return res;
+      })
+      .catch(updateReason => {
+        events.emitWarn(
+          `Error updating Cluster ${cluster.name} to Elroy: ${updateReason}`
+        );
+        throw updateReason;
+      });
+  }
+}
+module.exports = ElroySync;

--- a/test/unit/lib/elroy-sync.spec.js
+++ b/test/unit/lib/elroy-sync.spec.js
@@ -123,6 +123,6 @@ describe("ElroySync", () => {
           done();
         }, 3000);
       });
-    });
+    }).timeout(5000);
   });
 });

--- a/test/unit/lib/elroy-sync.spec.js
+++ b/test/unit/lib/elroy-sync.spec.js
@@ -1,0 +1,128 @@
+"use strict";
+
+const os = require("os");
+const expect = require("chai").expect;
+const Promise = require("bluebird");
+const mockery = require("mockery");
+const request = require("request-promise");
+const errors = require("request-promise/errors");
+const EventEmitter = require("events").EventEmitter;
+
+const YamlHandler = require("../../../src/util/yaml-handler");
+const EventHandler = require("../../../src/util/event-handler");
+const eventHandler = new EventHandler();
+/* used to debug events */
+eventHandler.on("debug", function(msg) {
+  console.log(`Received DEBUG message: ${msg}`);
+});
+eventHandler.on("info", function(msg) {
+  console.log(`Received INFO message: ${msg}`);
+});
+eventHandler.on("warn", function(msg) {
+  console.log(`Received WARN message: ${msg}`);
+});
+eventHandler.on("fatal", function(msg) {
+  console.log(`Received FATAL message: ${msg}`);
+});
+/* */
+
+describe("ElroySync", () => {
+  describe("match clusters", () => {
+    before(function(done) {
+      mockery.enable({
+        warnOnReplace: false,
+        warnOnUnregistered: false,
+        useCleanCache: true
+      });
+
+      mockery.registerMock("request-promise", function() {
+        return Promise.resolve({
+          count: 3,
+          items: [
+            { name: "test-fixture", active: true },
+            { name: "other-test-fixture", active: true },
+            { name: "deactivate-me", active: true }
+          ]
+        });
+      });
+      console.log("Registering mock");
+      done();
+    });
+
+    after(function(done) {
+      mockery.disable();
+      mockery.deregisterAll();
+      done();
+    });
+
+    it("should remove non-existent environments", done => {
+      return Promise.coroutine(function*() {
+        const ElroySync = require("../../../src/lib/elroy-sync");
+        const clusterDefs = yield YamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
+        console.log("cluster def counts: " + clusterDefs.length);
+        let updated = yield ElroySync.RemoveDeploymentEnvironments(
+          clusterDefs,
+          eventHandler,
+          { elroyUrl: "http://some-url.com", elroySecret: "xxxxx" }
+        );
+
+        expect(updated.length).to.equal(1);
+        done();
+      })().catch(err => {
+        done(err);
+      });
+    });
+  });
+
+  describe("Retry Sync", () => {
+    let retryCount = 0;
+    eventHandler.on("warn", msg => {
+      if (msg.includes("retrying")) {
+        retryCount++;
+      }
+    });
+    before(function(done) {
+      mockery.enable({
+        warnOnReplace: false,
+        warnOnUnregistered: false,
+        useCleanCache: true
+      });
+      mockery.registerMock("request-promise", function() {
+        return Promise.reject(
+          new errors.StatusCodeError(504, {}, {}, { statusCode: 504 })
+        );
+      });
+      console.log("Registering mock");
+      done();
+    });
+
+    after(function(done) {
+      mockery.disable();
+      mockery.deregisterAll();
+      done();
+    });
+
+    it("should retry 3 times", done => {
+      return Promise.coroutine(function*() {
+        const ElroySync = require("../../../src/lib/elroy-sync");
+        const clusterDefs = yield YamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
+        let updated = yield ElroySync.SaveToElroy(
+          clusterDefs[0],
+          eventHandler,
+          { elroyUrl: "http://some-url.com", elroySecret: "xxxxx" },
+          retryCount
+        );
+        done("Should not have reached here");
+      })().catch(err => {
+        setTimeout(function() {
+          expect(retryCount).to.equal(3);
+          done();
+        }, 3000);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We don't want to send the SHA or deployId as empty strings, but we should be sending the config. This sets the config to an empty object for now.  

Will also use this PR to fix https://github.com/InVisionApp/elroy/issues/220
