### PR TITLE
Issues/65 sync elroy

### DIFF
--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -139,7 +139,6 @@ class Deploymentizer {
       } else {
         this.events.emitInfo(`Syncing active clusters to elroy is disabled...`);
       }
-      return;
       //Merge the definitions, render templates and save (if enabled)
       let processClusters = [];
       for (let i = 0; i < clusterDefs.length; i++) {

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -119,12 +119,19 @@ class Deploymentizer {
 
       if (this.options.elroyUrl && this.options.elroySecret) {
         this.events.emitInfo(`Saving to elroy is enabled`);
-        this.events.emitInfo(`Checking for environments to deactivate`);
-        yield ElroySync.RemoveDeploymentEnvironments(
-          clusterDefs,
-          this.events,
-          this.options
-        );
+        if (this.options.clusterName || this.options.clusterType) {
+          this.events.emitInfo(
+            `Skipping deactivating clusters since clusterType ${this.options
+              .clusterType} or clusterName ${this.options.clusterName} is set`
+          );
+        } else {
+          this.events.emitInfo(`Checking for environments to deactivate`);
+          yield ElroySync.RemoveDeploymentEnvironments(
+            clusterDefs,
+            this.events,
+            this.options
+          );
+        }
       }
 
       //Merge the definitions, render templates and save (if enabled)

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -117,7 +117,11 @@ class Deploymentizer {
         this.paths.cluster
       );
 
-      if (this.options.elroyUrl && this.options.elroySecret) {
+      if (
+        this.options.elroyUrl &&
+        this.options.elroySecret &&
+        this.options.elroyOnly
+      ) {
         this.events.emitInfo(`Saving to elroy is enabled`);
         if (this.options.clusterName || this.options.clusterType) {
           this.events.emitInfo(
@@ -132,8 +136,10 @@ class Deploymentizer {
             this.options
           );
         }
+      } else {
+        this.events.emitInfo(`Syncing active clusters to elroy is disabled...`);
       }
-
+      return;
       //Merge the definitions, render templates and save (if enabled)
       let processClusters = [];
       for (let i = 0; i < clusterDefs.length; i++) {


### PR DESCRIPTION
This is a fix for #65 . This can happen when a user is running deploymentizer via jet locally. I added a check to make sure we only deactivate clusters if running via elroyOnly and we are not limiting the generation of cluster defs by type or name. Also added more logging. Tested locally against elroy in testing.

NOTE: we need to update the `kuberetes-coreos` repo with the correct version of deploymentizer