### PR TITLE
Adds _verifyImagesForCommitId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dump.rdb
 
 # Test
 generated
+/InVisionApp_kit-deploymentizer.aes

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "kit-deploymentizer",
   "version": "0.0.0-semantic-release",
-  "description":
-    "This will be a docker image that will intelligently build deployment files as to allow reusability of environment variables and other forms of configuration. It will also support aggregating these deployments for multiple clusters. In the end, it will generate a list of clusters and a list of deployment files for each of these clusters.",
+  "description": "This will be a docker image that will intelligently build deployment files as to allow reusability of environment variables and other forms of configuration. It will also support aggregating these deployments for multiple clusters. In the end, it will generate a list of clusters and a list of deployment files for each of these clusters.",
   "repository": {
     "type": "git",
     "url": "git://github.com/InVisionApp/kit-deploymentizer"
@@ -50,5 +49,8 @@
     "prettier": "1.7.4",
     "mockery": "2.1.0"
   },
-  "files": ["LICENSE", "src"]
+  "files": [
+    "LICENSE",
+    "src"
+  ]
 }

--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -49,7 +49,8 @@ class Deploymentizer {
       clusterType: args.clusterType || undefined,
       clusterName: args.clusterName || undefined,
       deployId: args.deployId || undefined,
-      fastRollback: args.fastRollback || false
+      fastRollback: args.fastRollback || false,
+      commitId: args.commitId
     };
     this.options.conf = this.parseConf(args.conf);
     this.events = new EventHandler();
@@ -260,7 +261,8 @@ class Deploymentizer {
           this.options.resource,
           this.events,
           this.options.deployId,
-          this.options.fastRollback
+          this.options.fastRollback,
+          this.options.commitId
         );
         return Promise.all([elroyProm, generator.process()]);
       }

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -48,6 +48,7 @@ class Generator {
 	 * @param	{[type]} eventHandler 		to log events to
 	 * @param	{[type]} deployId								deployId to use when generating manifests, switch to uuid from elroy
 	 * @param	{[type]} fastRollback			determines if fastRollback support is enabled. used by manifest generation
+	 * @param	{[type]} commitId   			(optional) The SHA of the commit that originated this generation request
 	 */
   constructor(
     clusterDef,
@@ -59,7 +60,8 @@ class Generator {
     resource,
     eventHandler,
     deployId,
-    fastRollback
+    fastRollback,
+    commitId
   ) {
     this.options = {
       clusterDef: clusterDef,
@@ -69,7 +71,8 @@ class Generator {
       save: save || false,
       resource: resource || undefined,
       deployId: deployId || undefined,
-      fastRollback: fastRollback || false
+      fastRollback: fastRollback || false,
+      commitId: commitId || undefined
     };
     this.configPlugin = configPlugin;
     this.eventHandler = eventHandler;
@@ -283,12 +286,57 @@ class Generator {
         }
       }
 
+      // make sure that at least one of the generated container images matches the commit SHA that spawned this
+      let commitId = this.options.commitId;
+      Generator._verifyImagesForCommitId(localConfig, commitId);
+      if (commitId) {
+        this.eventHandler.emitInfo(
+          `Verified that generated images are valid for commitId '${commitId}'`
+        );
+      }
+
       // if service info, append
       if (resource.svc) {
         localConfig.svc = resource.svc;
       }
       return localConfig;
     }).bind(this)();
+  }
+
+  /**
+   * Verifies that the images being added here match the intended commit SHA
+   * @param	{[type]} localConfig	the localConfig to validate
+   * @param	{[type]} commitId	  	SHA from the deploy
+   * @return will throw an error if it's not valid
+   */
+  static _verifyImagesForCommitId(localConfig, commitId) {
+    if (!commitId) {
+      return;
+    }
+    const imageSHARegex = /:.+-([a-f0-9]+)/i;
+    let imageSHAs = _.reduce(
+      localConfig,
+      function(result, value, key) {
+        if (_.has(value, "image")) {
+          let match = imageSHARegex.exec(value.image || "");
+          if (!match || match.length < 1) {
+            return result;
+          }
+          let imageSHA = match[1];
+          if (imageSHA) {
+            result.push(imageSHA);
+          }
+        }
+        return result;
+      },
+      []
+    );
+
+    if (imageSHAs.length > 0 && !_.includes(imageSHAs, commitId)) {
+      throw new Error(
+        `This kit manifest generation was for commitId '${commitId}', but none of the SHAs from images (${imageSHAs}) match that.`
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
... which makes sure we're generating stuff for the right commitId

partial InVisionApp/kit-server#282
still needs the part in kit-server where we thread through the commitId down to deploymentizer