### PR TITLE
Revert "setting image for container in generator"

### DIFF
--- a/src/lib/deploymentizer.js
+++ b/src/lib/deploymentizer.js
@@ -101,7 +101,7 @@ class Deploymentizer {
         this.paths.type
       );
 
-      // Load image tag (usage based on Resource Spec or cluster spec)
+      // Load image tag (usage based on Resource Spec or cluster spec
       const imageResources = yield yamlHandler.loadImageDefinitions(
         this.paths.images
       );

--- a/src/plugin/env-api-client.js
+++ b/src/plugin/env-api-client.js
@@ -3,6 +3,7 @@
 const Promise = require("bluebird");
 const rp = require("request-promise");
 const logger = require("log4js").getLogger();
+const EventEmitter = require("events");
 
 /**
  * Class for accessing the EnvApi Service.

--- a/test/unit/lib/generator.spec.js
+++ b/test/unit/lib/generator.spec.js
@@ -1,17 +1,13 @@
 "use strict";
 
 const os = require("os");
+const expect = require("chai").expect;
 const Promise = require("bluebird");
-const YamlHandler = require("../../../src/util/yaml-handler");
+const yamlHandler = require("../../../src/util/yaml-handler");
 const EventHandler = require("../../../src/util/event-handler");
 const Generator = require("../../../src/lib/generator");
 const fse = require("fs-extra");
 const path = require("path");
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-chai.should();
-const expect = chai.expect;
 
 const configStub = {
   fetch: function() {
@@ -27,58 +23,67 @@ const configStub = {
 };
 
 describe("Generator", () => {
-  it("should not fail with empty cluster", () => {
-    return YamlHandler.loadClusterDefinitions(
-      "./test/fixture/empty-clusters"
-    ).should.be.fulfilled.then(clusterDefs => {
-      const clusterDef = clusterDefs[0];
-      const generator = new Generator(
-        clusterDef,
-        {},
-        "",
-        os.tmpdir(),
-        true,
-        configStub,
-        "testrosie",
-        new EventHandler()
-      );
-      return generator.process().should.be.fullfilled;
+  describe("with empty cluster", () => {
+    it("should not fail", done => {
+      return Promise.coroutine(function*() {
+        const eventHandler = new EventHandler();
+        const clusterDefs = yield yamlHandler.loadClusterDefinitions(
+          "./test/fixture/empty-clusters"
+        );
+        const clusterDef = clusterDefs[0];
+        const generator = new Generator(
+          clusterDef,
+          {},
+          "",
+          os.tmpdir(),
+          true,
+          configStub,
+          "testrosie",
+          eventHandler
+        );
+        expect(clusterDef).to.exist;
+        yield generator.process();
+        done();
+      })().catch(err => {
+        done(err);
+      });
     });
   });
 
-  it("should create valid service file with valid cluster", () => {
-    return YamlHandler.loadClusterDefinitions(
-      "./test/fixture/clusters"
-    ).should.be.fulfilled.then(clusterDefs => {
-      const clusterDef = clusterDefs[1];
-      const generator = new Generator(
-        clusterDef,
-        {},
-        "./test/fixture/resources",
-        os.tmpdir(),
-        true,
-        configStub
-      );
-      if (!fse.existsSync(path.join(os.tmpdir(), clusterDef.name()))) {
-        fse.mkdirsSync(path.join(os.tmpdir(), clusterDef.name()));
-      }
-      // manually merge this here
-      clusterDef.configuration().svc = clusterDef.resources().auth.svc;
-
-      generator
-        .processService(clusterDef.resources().auth, clusterDef.configuration())
-        .should.be.fulfilled.then(() => {
-          YamlHandler.loadFile(
-            path.join(os.tmpdir(), clusterDef.name(), "auth-svc.yaml")
-          ).should.be.fulfilled.then(svc => {
-            const expected = {
-              apiVersion: "v1",
-              kind: "Service",
-              metadata: { name: "auth-svc", labels: { app: "invisionapp" } }
-            };
-            Promise.resolve(svc).should.eventually.deep.equal(expected);
-          });
-        });
+  describe("with valid cluster", () => {
+    it("should create valid service file", done => {
+      return Promise.coroutine(function*() {
+        const clusterDefs = yield yamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
+        const clusterDef = clusterDefs[1];
+        const generator = new Generator(
+          clusterDef,
+          {},
+          "./test/fixture/resources",
+          os.tmpdir(),
+          true,
+          configStub
+        );
+        expect(clusterDef).to.exist;
+        if (!fse.existsSync(path.join(os.tmpdir(), clusterDef.name()))) {
+          fse.mkdirsSync(path.join(os.tmpdir(), clusterDef.name()));
+        }
+        // manually merge this here
+        clusterDef.configuration().svc = clusterDef.resources().auth.svc;
+        yield generator.processService(
+          clusterDef.resources().auth,
+          clusterDef.configuration()
+        );
+        const svc = yield yamlHandler.loadFile(
+          path.join(os.tmpdir(), clusterDef.name(), "auth-svc.yaml")
+        );
+        expect(svc.metadata.name).to.equal("auth-svc");
+        expect(svc.metadata.labels.app).to.equal("invisionapp");
+        done();
+      })().catch(err => {
+        done(err);
+      });
     });
   });
 
@@ -93,20 +98,12 @@ describe("Generator", () => {
       }
     };
 
-    it("should send event to DD without SHA", () => {
-      let events = new EventHandler();
-      events.on("metric", function(msg) {
-        expect(msg).to.deep.equal({
-          kind: "event",
-          title: "No SHA passed in",
-          text: "No SHA passsed in for resource auth",
-          tags: { app: "kit_deploymentizer", kit_resource: "auth" }
-        });
-      });
-
-      return YamlHandler.loadClusterDefinitions(
-        "./test/fixture/clusters"
-      ).should.be.fulfilled.then(clusterDefs => {
+    it("should create copy of config, merging in values from resource", done => {
+      const eventHandler = new EventHandler();
+      return Promise.coroutine(function*() {
+        const clusterDefs = yield yamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
         const clusterDef = clusterDefs[3];
         const generator = new Generator(
           clusterDef,
@@ -116,24 +113,49 @@ describe("Generator", () => {
           true,
           configStub,
           undefined,
-          events
+          eventHandler
         );
+        expect(clusterDef).to.exist;
+        if (!fse.existsSync(path.join(os.tmpdir(), clusterDef.name()))) {
+          fse.mkdirsSync(path.join(os.tmpdir(), clusterDef.name()));
+        }
         // we add the image tag here, since we dont preload the base cluster def in this test
         clusterDef.resources().auth.containers["auth-con"].image_tag =
           "node-auth";
-
-        return generator._createLocalConfiguration(
+        const localConfig = yield generator._createLocalConfiguration(
           clusterDef.configuration(),
           "auth",
           clusterDef.resources().auth
         );
+        expect(localConfig).to.exist;
+        expect(localConfig.svc).to.exist;
+        expect(localConfig).to.not.equal(clusterDef.configuration());
+        expect(localConfig.name).to.equal("auth");
+        expect(localConfig["auth-con"].image).to.equal(developImage);
+        expect(localConfig["auth-con"].env).to.include({
+          name: "test",
+          value: "testvalue"
+        });
+        expect(localConfig["auth-con"].env).to.include({
+          name: "ENV_ONE",
+          value: "value-one"
+        });
+        expect(localConfig["auth-con"].env).to.include({
+          name: "ENV_THREE",
+          value: "value-three"
+        });
+        done();
+      })().catch(err => {
+        done(err);
       });
     });
 
-    it("should create copy of config, merging in values from resource", () => {
-      return YamlHandler.loadClusterDefinitions(
-        "./test/fixture/clusters"
-      ).should.be.fulfilled.then(clusterDefs => {
+    it("should create copy of config, without plugin", done => {
+      const eventHandler = new EventHandler();
+      return Promise.coroutine(function*() {
+        const clusterDefs = yield yamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
         const clusterDef = clusterDefs[3];
         const generator = new Generator(
           clusterDef,
@@ -141,50 +163,47 @@ describe("Generator", () => {
           "./test/fixture/resources",
           os.tmpdir(),
           true,
-          configStub,
           undefined,
-          new EventHandler()
+          undefined,
+          eventHandler
         );
-
+        expect(clusterDef).to.exist;
         if (!fse.existsSync(path.join(os.tmpdir(), clusterDef.name()))) {
           fse.mkdirsSync(path.join(os.tmpdir(), clusterDef.name()));
         }
         // we add the image tag here, since we dont preload the base cluster def in this test
         clusterDef.resources().auth.containers["auth-con"].image_tag =
           "node-auth";
-
-        return generator
-          ._createLocalConfiguration(
-            clusterDef.configuration(),
-            "auth",
-            clusterDef.resources().auth
-          )
-          .should.be.fulfilled.then(localConfig => {
-            expect(localConfig).to.exist;
-            expect(localConfig.svc).to.exist;
-            expect(localConfig).to.not.equal(clusterDef.configuration());
-            expect(localConfig.name).to.equal("auth");
-            expect(localConfig["auth-con"].image).to.equal(developImage);
-            expect(localConfig["auth-con"].env).to.include({
-              name: "test",
-              value: "testvalue"
-            });
-            expect(localConfig["auth-con"].env).to.include({
-              name: "ENV_ONE",
-              value: "value-one"
-            });
-            expect(localConfig["auth-con"].env).to.include({
-              name: "ENV_THREE",
-              value: "value-three"
-            });
-          });
+        const localConfig = yield generator._createLocalConfiguration(
+          clusterDef.configuration(),
+          "auth",
+          clusterDef.resources().auth
+        );
+        expect(localConfig).to.exist;
+        expect(localConfig.svc).to.exist;
+        expect(localConfig).to.not.equal(clusterDef.configuration());
+        expect(localConfig["auth-con"].name).to.equal("auth");
+        expect(localConfig["auth-con"].image).to.equal(developImage);
+        expect(localConfig["auth-con"].env).to.include({
+          name: "test",
+          value: "testvalue"
+        });
+        expect(localConfig["auth-con"].env).to.not.include({
+          name: "ENV_ONE",
+          value: "value-one"
+        });
+        done();
+      })().catch(err => {
+        done(err);
       });
     });
 
-    it("should create copy of config, without plugin", () => {
-      return YamlHandler.loadClusterDefinitions(
-        "./test/fixture/clusters"
-      ).should.be.fulfilled.then(clusterDefs => {
+    it("should succeed when commitId is specified", done => {
+      const eventHandler = new EventHandler();
+      return Promise.coroutine(function*() {
+        const clusterDefs = yield yamlHandler.loadClusterDefinitions(
+          "./test/fixture/clusters"
+        );
         const clusterDef = clusterDefs[3];
         const generator = new Generator(
           clusterDef,
@@ -194,77 +213,24 @@ describe("Generator", () => {
           true,
           undefined,
           undefined,
-          new EventHandler()
+          eventHandler
         );
         expect(clusterDef).to.exist;
-
         if (!fse.existsSync(path.join(os.tmpdir(), clusterDef.name()))) {
           fse.mkdirsSync(path.join(os.tmpdir(), clusterDef.name()));
         }
         // we add the image tag here, since we dont preload the base cluster def in this test
         clusterDef.resources().auth.containers["auth-con"].image_tag =
           "node-auth";
-
-        return generator
-          ._createLocalConfiguration(
-            clusterDef.configuration(),
-            "auth",
-            clusterDef.resources().auth
-          )
-          .should.be.fulfilled.then(localConfig => {
-            expect(localConfig).to.exist;
-            expect(localConfig.svc).to.exist;
-            expect(localConfig).to.not.equal(clusterDef.configuration());
-            expect(localConfig["auth-con"].name).to.equal("auth");
-            expect(localConfig["auth-con"].image).to.equal(developImage);
-            expect(localConfig["auth-con"].env).to.include({
-              name: "test",
-              value: "testvalue"
-            });
-            expect(localConfig["auth-con"].env).to.not.include({
-              name: "ENV_ONE",
-              value: "value-one"
-            });
-          });
-      });
-    });
-
-    it("should set the image as commitId when is passed in", () => {
-      return YamlHandler.loadClusterDefinitions(
-        "./test/fixture/clusters"
-      ).should.be.fulfilled.then(clusterDefs => {
-        const sha = "3154cf1fff0c547c9628c266f6c013b53228fdc8";
-        const clusterDef = clusterDefs[3];
-        let auth = clusterDef.cluster.resources["auth"];
-        auth.containers["auth-con"].image_tag = "invision/auth";
-        const generator = new Generator(
-          clusterDef,
-          imageResources,
-          "./test/fixture/resources",
-          os.tmpdir(),
-          true,
-          undefined,
-          undefined,
-          new EventHandler(),
-          undefined,
-          undefined,
-          sha
+        const localConfig = yield generator._createLocalConfiguration(
+          clusterDef.configuration(),
+          "auth",
+          clusterDef.resources().auth
         );
-        expect(clusterDef).to.exist;
-
-        return generator
-          ._createLocalConfiguration(
-            clusterDef.configuration(),
-            "auth",
-            clusterDef.resources().auth
-          )
-          .should.be.fulfilled.then(localConfig => {
-            expect(localConfig).to.exist;
-            expect(localConfig.svc).to.exist;
-            expect(localConfig["auth-con"].image).to.equal(
-              `quay.io/invision/auth:release-${sha}`
-            );
-          });
+        expect(localConfig).to.exist;
+        done();
+      })().catch(err => {
+        done(err);
       });
     });
   });
@@ -279,38 +245,45 @@ describe("Generator", () => {
       }
     };
 
-    it("should ignore blank commitId", () => {
-      return Promise.resolve(
-        Generator._verifyImagesForCommitId(resourceConfig)
-      ).should.be.fulfilled.then(() => {
-        return Promise.resolve(
-          Generator._verifyImagesForCommitId(resourceConfig, null)
-        ).should.be.fulfilled;
+    it("should ignore blank commitId", done => {
+      return Promise.coroutine(function*() {
+        Generator._verifyImagesForCommitId(resourceConfig);
+        Generator._verifyImagesForCommitId(resourceConfig, null);
+        done();
+      })().catch(err => {
+        done(err);
       });
     });
 
-    it("should ignore a ResourceConfig with no containers", () => {
-      return Promise.resolve(Generator._verifyImagesForCommitId({}, "abc1"))
-        .should.be.fulfilled;
+    it("should ignore a ResourceConfig with no containers", done => {
+      return Promise.coroutine(function*() {
+        Generator._verifyImagesForCommitId({}, "abc1");
+        done();
+      })().catch(err => {
+        done(err);
+      });
     });
 
-    it("should fail for the wrong commitId", () => {
-      try {
+    it("should fail for the wrong commitId", done => {
+      return Promise.coroutine(function*() {
         Generator._verifyImagesForCommitId(resourceConfig, "wrong");
-      } catch (err) {
-        expect(err.message).to.be.equal(
-          `This kit manifest generation was for commitId 'wrong', but none of the SHAs from images (abc1,abc2) match that.`
+        done(
+          new Error(
+            "Expected _verifyImagesForCommitId to throw an error because it was for the wrong commitId."
+          )
         );
-      }
+      })().catch(err => {
+        done();
+      });
     });
 
-    it("should succeed for the right commitId(s)", () => {
-      return Promise.resolve(
-        Generator._verifyImagesForCommitId(resourceConfig, "abc1")
-      ).should.be.fulfilled.then(() => {
-        return Promise.resolve(
-          Generator._verifyImagesForCommitId(resourceConfig, "abc2")
-        ).should.be.fulfilled;
+    it("should succeed for the right commitId(s)", done => {
+      return Promise.coroutine(function*() {
+        Generator._verifyImagesForCommitId(resourceConfig, "abc1");
+        Generator._verifyImagesForCommitId(resourceConfig, "abc2");
+        done();
+      })().catch(err => {
+        done(err);
       });
     });
   });

--- a/test/unit/plugin/env-api-client-v3.spec.js
+++ b/test/unit/plugin/env-api-client-v3.spec.js
@@ -1,16 +1,10 @@
 "use strict";
 
+var expect = require("chai").expect;
 const Promise = require("bluebird");
 const sinon = require("sinon");
 const ClusterDefinition = require("../../../src/lib/cluster-definition");
 const ApiConfig = require("../../../src/plugin/env-api-client-v3");
-const EventHandler = require("../../../src/util/event-handler");
-
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
-chai.should();
-const expect = chai.expect;
 
 describe("ENV API Client Configuration plugin", () => {
   let ApiConfig;
@@ -131,45 +125,6 @@ describe("ENV API Client Configuration plugin", () => {
         expect(err.message).to.have.string("Invalid argument for 'cluster'");
         done();
       });
-    });
-
-    it("should send metrics via events", () => {
-      const events = new EventHandler();
-      let sentMetric = false;
-      events.on("metric", function(msg) {
-        sentMetric = true;
-      });
-      const cluster = {
-        kind: "ClusterNamespace",
-        metadata: {
-          name: "staging-cluster",
-          type: "staging",
-          environment: "staging",
-          domain: "somewbesite.com",
-          restricted: true
-        }
-      };
-      const config = {
-        kind: "ResourceConfig",
-        env: [{ name: "a", value: 1 }, { name: "b", value: 2 }]
-      };
-      const clusterDef = new ClusterDefinition(cluster, config);
-
-      const options = {
-        apiUrl: "https://envapi.tools.shared-multi.k8s.invision.works/api",
-        events: events
-      };
-
-      var rp = sinon.stub();
-      rp.onFirstCall().returns(resV3Valid);
-      const apiConfig = new ApiConfig(options);
-      apiConfig.request = rp;
-
-      return apiConfig
-        .fetch(testService, clusterDef)
-        .should.be.fulfilled.then(() => {
-          expect(sentMetric).to.equal(true);
-        });
     });
 
     it("should call request to v3 and succeed", done => {


### PR DESCRIPTION
Reverts InVisionApp/kit-deploymentizer#72

We want to have a version of this lib for testing this image branch for a while -- but we don't want to deploy it yet and either stop the dev cycle 
(this could be solved with feature-flags but actually we don't have one)