### PR TITLE
Add default code-coverage section in preparation for ev2 migration

### DIFF
--- a/in-repo.yaml
+++ b/in-repo.yaml
@@ -3,3 +3,7 @@ owner:
   active:
     team: engineering-velocity
     since: 2016-11-29
+
+code-coverage:
+  # please see https://invisionapp.atlassian.net/wiki/spaces/ICT/pages/888799838/Establishing+code+coverage+goals for how to set this value appropriately
+  goal-percent: 100


### PR DESCRIPTION
Add default code-coverage section in preparation for ev2 migration

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖